### PR TITLE
Feat/search input

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,10 @@
       "name": "untitled",
       "version": "0.1.0",
       "dependencies": {
+        "@chakra-ui/icons": "^2.1.0",
+        "@chakra-ui/react": "^2.8.0",
+        "@emotion/react": "^11.11.1",
+        "@emotion/styled": "^11.11.0",
         "@reduxjs/toolkit": "^1.9.5",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
@@ -17,6 +21,7 @@
         "@types/react": "^18.2.20",
         "@types/react-dom": "^18.2.7",
         "axios": "^1.4.0",
+        "framer-motion": "^10.16.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.1.2",
@@ -2003,6 +2008,1178 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
+    "node_modules/@chakra-ui/accordion": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-2.3.0.tgz",
+      "integrity": "sha512-A4TkRw3Jnt+Fam6dSSJ62rskdrvjF3JGctYcfXlojfFIpHPuIw4pDwfZgNAxlaxWkcj0e7JJKlQ88dnZW+QfFg==",
+      "dependencies": {
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/transition": "2.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/alert": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-2.2.0.tgz",
+      "integrity": "sha512-De+BT88iYOu3Con7MxQeICb1SwgAdVdgpHIYjTh3qvGlNXAQjs81rhG0fONXvwW1FIYletvr9DY2Tlg8xJe7tQ==",
+      "dependencies": {
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/spinner": "2.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/anatomy": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.2.0.tgz",
+      "integrity": "sha512-cD8Ms5C8+dFda0LrORMdxiFhAZwOIY1BSlCadz6/mHUIgNdQy13AHPrXiq6qWdMslqVHq10k5zH7xMPLt6kjFg=="
+    },
+    "node_modules/@chakra-ui/avatar": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-2.3.0.tgz",
+      "integrity": "sha512-8gKSyLfygnaotbJbDMHDiJoF38OHXUYVme4gGxZ1fLnQEdPVEaIWfH+NndIjOM0z8S+YEFnT9KyGMUtvPrBk3g==",
+      "dependencies": {
+        "@chakra-ui/image": "2.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/breadcrumb": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-2.2.0.tgz",
+      "integrity": "sha512-4cWCG24flYBxjruRi4RJREWTGF74L/KzI2CognAW/d/zWR0CjiScuJhf37Am3LFbCySP6WSoyBOtTIoTA4yLEA==",
+      "dependencies": {
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/breakpoint-utils": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/breakpoint-utils/-/breakpoint-utils-2.0.8.tgz",
+      "integrity": "sha512-Pq32MlEX9fwb5j5xx8s18zJMARNHlQZH2VH1RZgfgRDpp7DcEgtRW5AInfN5CfqdHLO1dGxA7I3MqEuL5JnIsA==",
+      "dependencies": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "node_modules/@chakra-ui/button": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-2.1.0.tgz",
+      "integrity": "sha512-95CplwlRKmmUXkdEp/21VkEWgnwcx2TOBG6NfYlsuLBDHSLlo5FKIiE2oSi4zXc4TLcopGcWPNcm/NDaSC5pvA==",
+      "dependencies": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/spinner": "2.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/card": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/card/-/card-2.2.0.tgz",
+      "integrity": "sha512-xUB/k5MURj4CtPAhdSoXZidUbm8j3hci9vnc+eZJVDqhDOShNlD6QeniQNRPRys4lWAQLCbFcrwL29C8naDi6g==",
+      "dependencies": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/checkbox": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-2.3.0.tgz",
+      "integrity": "sha512-fX7M5sQK27aFWoj7vqnPkf1Q3AHmML/5dIRYfm7HEIsZXYH2C1CkM6+dijeSWIk6a0mp0r3el6SNDUti2ehH8g==",
+      "dependencies": {
+        "@chakra-ui/form-control": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/visually-hidden": "2.1.0",
+        "@zag-js/focus-visible": "0.10.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/clickable": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-2.1.0.tgz",
+      "integrity": "sha512-flRA/ClPUGPYabu+/GLREZVZr9j2uyyazCAUHAdrTUEdDYCr31SVGhgh7dgKdtq23bOvAQJpIJjw/0Bs0WvbXw==",
+      "dependencies": {
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/close-button": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/close-button/-/close-button-2.1.0.tgz",
+      "integrity": "sha512-KfJcz6UAaR2dDWSIv6UrCGkZQS54Fjl+DEEVOUTJ7gf4KOP4FQZCkv8hqsAB9FeCtnwU43adq2oaw3aZH/Uzew==",
+      "dependencies": {
+        "@chakra-ui/icon": "3.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/color-mode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/color-mode/-/color-mode-2.2.0.tgz",
+      "integrity": "sha512-niTEA8PALtMWRI9wJ4LL0CSBDo8NBfLNp4GD6/0hstcm3IlbBHTVKxN6HwSaoNYfphDQLxCjT4yG+0BJA5tFpg==",
+      "dependencies": {
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/control-box": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-2.1.0.tgz",
+      "integrity": "sha512-gVrRDyXFdMd8E7rulL0SKeoljkLQiPITFnsyMO8EFHNZ+AHt5wK4LIguYVEq88APqAGZGfHFWXr79RYrNiE3Mg==",
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/counter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-2.1.0.tgz",
+      "integrity": "sha512-s6hZAEcWT5zzjNz2JIWUBzRubo9la/oof1W7EKZVVfPYHERnl5e16FmBC79Yfq8p09LQ+aqFKm/etYoJMMgghw==",
+      "dependencies": {
+        "@chakra-ui/number-utils": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/css-reset": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/css-reset/-/css-reset-2.2.0.tgz",
+      "integrity": "sha512-nn7hjquIrPwCzwI4d/Y4wzM5A5xAeswREOfT8gT0Yd+U+Qnw3pPT8NPLbNJ3DvuOfJaCV6/N5ld/6RRTgYF/sQ==",
+      "peerDependencies": {
+        "@emotion/react": ">=10.0.35",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/descendant": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/descendant/-/descendant-3.1.0.tgz",
+      "integrity": "sha512-VxCIAir08g5w27klLyi7PVo8BxhW4tgU/lxQyujkmi4zx7hT9ZdrcQLAted/dAa+aSIZ14S1oV0Q9lGjsAdxUQ==",
+      "dependencies": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/dom-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/dom-utils/-/dom-utils-2.1.0.tgz",
+      "integrity": "sha512-ZmF2qRa1QZ0CMLU8M1zCfmw29DmPNtfjR9iTo74U5FPr3i1aoAh7fbJ4qAlZ197Xw9eAW28tvzQuoVWeL5C7fQ=="
+    },
+    "node_modules/@chakra-ui/editable": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-3.1.0.tgz",
+      "integrity": "sha512-j2JLrUL9wgg4YA6jLlbU88370eCRyor7DZQD9lzpY95tSOXpTljeg3uF9eOmDnCs6fxp3zDWIfkgMm/ExhcGTg==",
+      "dependencies": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-focus-on-pointer-down": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/event-utils": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/event-utils/-/event-utils-2.0.8.tgz",
+      "integrity": "sha512-IGM/yGUHS+8TOQrZGpAKOJl/xGBrmRYJrmbHfUE7zrG3PpQyXvbLDP1M+RggkCFVgHlJi2wpYIf0QtQlU0XZfw=="
+    },
+    "node_modules/@chakra-ui/focus-lock": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-2.1.0.tgz",
+      "integrity": "sha512-EmGx4PhWGjm4dpjRqM4Aa+rCWBxP+Rq8Uc/nAVnD4YVqkEhBkrPTpui2lnjsuxqNaZ24fIAZ10cF1hlpemte/w==",
+      "dependencies": {
+        "@chakra-ui/dom-utils": "2.1.0",
+        "react-focus-lock": "^2.9.4"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/form-control": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/form-control/-/form-control-2.1.0.tgz",
+      "integrity": "sha512-3QmWG9v6Rx+JOwJP3Wt89+AWZxK0F1NkVAgXP3WVfE9VDXOKFRV/faLT0GEe2V+l7WZHF5PLdEBvKG8Cgw2mkA==",
+      "dependencies": {
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/hooks": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-2.2.0.tgz",
+      "integrity": "sha512-GZE64mcr20w+3KbCUPqQJHHmiFnX5Rcp8jS3YntGA4D5X2qU85jka7QkjfBwv/iduZ5Ei0YpCMYGCpi91dhD1Q==",
+      "dependencies": {
+        "@chakra-ui/react-utils": "2.0.12",
+        "@chakra-ui/utils": "2.0.15",
+        "compute-scroll-into-view": "1.0.20",
+        "copy-to-clipboard": "3.3.3"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/icon": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-3.1.0.tgz",
+      "integrity": "sha512-t6v0lGCXRbwUJycN8A/nDTuLktMP+LRjKbYJnd2oL6Pm2vOl99XwEQ5cAEyEa4XoseYNEgXiLR+2TfvgfNFvcw==",
+      "dependencies": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/icons": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.1.0.tgz",
+      "integrity": "sha512-pGFxFfQ/P5VnSRnTzK8zGAJxoxkxpHo/Br9ohRZdOpuhnIHSW7va0P53UoycEO5/vNJ/7BN0oDY0k9qurChcew==",
+      "dependencies": {
+        "@chakra-ui/icon": "3.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/image": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-2.1.0.tgz",
+      "integrity": "sha512-bskumBYKLiLMySIWDGcz0+D9Th0jPvmX6xnRMs4o92tT3Od/bW26lahmV2a2Op2ItXeCmRMY+XxJH5Gy1i46VA==",
+      "dependencies": {
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/input": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-2.1.0.tgz",
+      "integrity": "sha512-HItI2vq6vupCuixdzof4sIanGdLlszhDtlR5be5z8Nrda1RkXVqI+9CTJPbNsx2nIKEfwPt01pnT9mozoOSMMw==",
+      "dependencies": {
+        "@chakra-ui/form-control": "2.1.0",
+        "@chakra-ui/object-utils": "2.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/layout": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-2.3.0.tgz",
+      "integrity": "sha512-tp1/Bn+cHn0Q4HWKY62HtOwzhpH1GUA3i5fvs23HEhOEryTps05hyuQVeJ71fLqSs6f1QEIdm+9It+5WCj64vQ==",
+      "dependencies": {
+        "@chakra-ui/breakpoint-utils": "2.0.8",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/object-utils": "2.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/lazy-utils": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/lazy-utils/-/lazy-utils-2.0.5.tgz",
+      "integrity": "sha512-UULqw7FBvcckQk2n3iPO56TMJvDsNv0FKZI6PlUNJVaGsPbsYxK/8IQ60vZgaTVPtVcjY6BE+y6zg8u9HOqpyg=="
+    },
+    "node_modules/@chakra-ui/live-region": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-2.1.0.tgz",
+      "integrity": "sha512-ZOxFXwtaLIsXjqnszYYrVuswBhnIHHP+XIgK1vC6DePKtyK590Wg+0J0slDwThUAd4MSSIUa/nNX84x1GMphWw==",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/media-query": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-3.3.0.tgz",
+      "integrity": "sha512-IsTGgFLoICVoPRp9ykOgqmdMotJG0CnPsKvGQeSFOB/dZfIujdVb14TYxDU4+MURXry1MhJ7LzZhv+Ml7cr8/g==",
+      "dependencies": {
+        "@chakra-ui/breakpoint-utils": "2.0.8",
+        "@chakra-ui/react-env": "3.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/menu": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-2.2.0.tgz",
+      "integrity": "sha512-l7HQjriW4JGeCyxDdguAzekwwB+kHGDLxACi0DJNp37sil51SRaN1S1OrneISbOHVpHuQB+KVNgU0rqhoglVew==",
+      "dependencies": {
+        "@chakra-ui/clickable": "2.1.0",
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/lazy-utils": "2.0.5",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-animation-state": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-disclosure": "2.1.0",
+        "@chakra-ui/react-use-focus-effect": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-outside-click": "2.2.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/transition": "2.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/modal": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-2.3.0.tgz",
+      "integrity": "sha512-S1sITrIeLSf21LJ0Vz8xZhj5fWEud5z5Dl2dmvOEv1ezypgOrCCBdOEnnqCkoEKZDbKvzZWZXWR5791ikLP6+g==",
+      "dependencies": {
+        "@chakra-ui/close-button": "2.1.0",
+        "@chakra-ui/focus-lock": "2.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/transition": "2.1.0",
+        "aria-hidden": "^1.2.2",
+        "react-remove-scroll": "^2.5.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/number-input": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-2.1.0.tgz",
+      "integrity": "sha512-/gEAzQHhrMA+1rzyCMaN8OkKtUPuER6iA+nloYEYBoT7dH/EoNlRtBkiIQhDp+E4VpgZJ0SK3OVrm9/eBbtHHg==",
+      "dependencies": {
+        "@chakra-ui/counter": "2.1.0",
+        "@chakra-ui/form-control": "2.1.0",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-interval": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/number-utils": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/number-utils/-/number-utils-2.0.7.tgz",
+      "integrity": "sha512-yOGxBjXNvLTBvQyhMDqGU0Oj26s91mbAlqKHiuw737AXHt0aPllOthVUqQMeaYLwLCjGMg0jtI7JReRzyi94Dg=="
+    },
+    "node_modules/@chakra-ui/object-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/object-utils/-/object-utils-2.1.0.tgz",
+      "integrity": "sha512-tgIZOgLHaoti5PYGPTwK3t/cqtcycW0owaiOXoZOcpwwX/vlVb+H1jFsQyWiiwQVPt9RkoSLtxzXamx+aHH+bQ=="
+    },
+    "node_modules/@chakra-ui/pin-input": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-2.1.0.tgz",
+      "integrity": "sha512-x4vBqLStDxJFMt+jdAHHS8jbh294O53CPQJoL4g228P513rHylV/uPscYUHrVJXRxsHfRztQO9k45jjTYaPRMw==",
+      "dependencies": {
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/popover": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-2.2.0.tgz",
+      "integrity": "sha512-cTqXdgkU0vgK82AR1nWcC2MJYhEL/y6uTeprvO2+j4o2D0yPrzVMuIZZRl0abrQwiravQyVGEMgA5y0ZLYwbiQ==",
+      "dependencies": {
+        "@chakra-ui/close-button": "2.1.0",
+        "@chakra-ui/lazy-utils": "2.0.5",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-animation-state": "2.1.0",
+        "@chakra-ui/react-use-disclosure": "2.1.0",
+        "@chakra-ui/react-use-focus-effect": "2.1.0",
+        "@chakra-ui/react-use-focus-on-pointer-down": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/popper": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popper/-/popper-3.1.0.tgz",
+      "integrity": "sha512-ciDdpdYbeFG7og6/6J8lkTFxsSvwTdMLFkpVylAF6VNC22jssiWfquj2eyD4rJnzkRFPvIWJq8hvbfhsm+AjSg==",
+      "dependencies": {
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@popperjs/core": "^2.9.3"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/portal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/portal/-/portal-2.1.0.tgz",
+      "integrity": "sha512-9q9KWf6SArEcIq1gGofNcFPSWEyl+MfJjEUg/un1SMlQjaROOh3zYr+6JAwvcORiX7tyHosnmWC3d3wI2aPSQg==",
+      "dependencies": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/progress": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-2.2.0.tgz",
+      "integrity": "sha512-qUXuKbuhN60EzDD9mHR7B67D7p/ZqNS2Aze4Pbl1qGGZfulPW0PY8Rof32qDtttDQBkzQIzFGE8d9QpAemToIQ==",
+      "dependencies": {
+        "@chakra-ui/react-context": "2.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/provider": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/provider/-/provider-2.4.0.tgz",
+      "integrity": "sha512-KJ/TNczpY+EStQXa2Y5PZ+senlBHrY7P+RpBgJLBZLGkQUCS3APw5KvCwgpA0COb2M4AZXCjw+rm+Ko7ontlgA==",
+      "dependencies": {
+        "@chakra-ui/css-reset": "2.2.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-env": "3.1.0",
+        "@chakra-ui/system": "2.6.0",
+        "@chakra-ui/utils": "2.0.15"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0",
+        "@emotion/styled": "^11.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/radio": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-2.1.0.tgz",
+      "integrity": "sha512-WiRlSCqKWgy4m9106w4g77kcLYqBxqGhFRO1pTTJp99rxpM6jNadOeK+moEjqj64N9mSz3njEecMJftKKcOYdg==",
+      "dependencies": {
+        "@chakra-ui/form-control": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@zag-js/focus-visible": "0.10.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.8.0.tgz",
+      "integrity": "sha512-tV82DaqE4fMbLIWq58BYh4Ol3gAlNEn+qYOzx8bPrZudboEDnboq8aVfSBwWOY++MLWz2Nn7CkT69YRm91e5sg==",
+      "dependencies": {
+        "@chakra-ui/accordion": "2.3.0",
+        "@chakra-ui/alert": "2.2.0",
+        "@chakra-ui/avatar": "2.3.0",
+        "@chakra-ui/breadcrumb": "2.2.0",
+        "@chakra-ui/button": "2.1.0",
+        "@chakra-ui/card": "2.2.0",
+        "@chakra-ui/checkbox": "2.3.0",
+        "@chakra-ui/close-button": "2.1.0",
+        "@chakra-ui/control-box": "2.1.0",
+        "@chakra-ui/counter": "2.1.0",
+        "@chakra-ui/css-reset": "2.2.0",
+        "@chakra-ui/editable": "3.1.0",
+        "@chakra-ui/focus-lock": "2.1.0",
+        "@chakra-ui/form-control": "2.1.0",
+        "@chakra-ui/hooks": "2.2.0",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/image": "2.1.0",
+        "@chakra-ui/input": "2.1.0",
+        "@chakra-ui/layout": "2.3.0",
+        "@chakra-ui/live-region": "2.1.0",
+        "@chakra-ui/media-query": "3.3.0",
+        "@chakra-ui/menu": "2.2.0",
+        "@chakra-ui/modal": "2.3.0",
+        "@chakra-ui/number-input": "2.1.0",
+        "@chakra-ui/pin-input": "2.1.0",
+        "@chakra-ui/popover": "2.2.0",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/progress": "2.2.0",
+        "@chakra-ui/provider": "2.4.0",
+        "@chakra-ui/radio": "2.1.0",
+        "@chakra-ui/react-env": "3.1.0",
+        "@chakra-ui/select": "2.1.0",
+        "@chakra-ui/skeleton": "2.1.0",
+        "@chakra-ui/skip-nav": "2.1.0",
+        "@chakra-ui/slider": "2.1.0",
+        "@chakra-ui/spinner": "2.1.0",
+        "@chakra-ui/stat": "2.1.0",
+        "@chakra-ui/stepper": "2.3.0",
+        "@chakra-ui/styled-system": "2.9.1",
+        "@chakra-ui/switch": "2.1.0",
+        "@chakra-ui/system": "2.6.0",
+        "@chakra-ui/table": "2.1.0",
+        "@chakra-ui/tabs": "2.2.0",
+        "@chakra-ui/tag": "3.1.0",
+        "@chakra-ui/textarea": "2.1.0",
+        "@chakra-ui/theme": "3.2.0",
+        "@chakra-ui/theme-utils": "2.0.19",
+        "@chakra-ui/toast": "7.0.0",
+        "@chakra-ui/tooltip": "2.3.0",
+        "@chakra-ui/transition": "2.1.0",
+        "@chakra-ui/utils": "2.0.15",
+        "@chakra-ui/visually-hidden": "2.1.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0",
+        "@emotion/styled": "^11.0.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-children-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-children-utils/-/react-children-utils-2.0.6.tgz",
+      "integrity": "sha512-QVR2RC7QsOsbWwEnq9YduhpqSFnZGvjjGREV8ygKi8ADhXh93C8azLECCUVgRJF2Wc+So1fgxmjLcbZfY2VmBA==",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-context": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-context/-/react-context-2.1.0.tgz",
+      "integrity": "sha512-iahyStvzQ4AOwKwdPReLGfDesGG+vWJfEsn0X/NoGph/SkN+HXtv2sCfYFFR9k7bb+Kvc6YfpLlSuLvKMHi2+w==",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-env": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-3.1.0.tgz",
+      "integrity": "sha512-Vr96GV2LNBth3+IKzr/rq1IcnkXv+MLmwjQH6C8BRtn3sNskgDFD5vLkVXcEhagzZMCh8FR3V/bzZPojBOyNhw==",
+      "dependencies": {
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-types/-/react-types-2.0.7.tgz",
+      "integrity": "sha512-12zv2qIZ8EHwiytggtGvo4iLT0APris7T0qaAWqzpUGS0cdUtR8W+V1BJ5Ocq+7tA6dzQ/7+w5hmXih61TuhWQ==",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-animation-state": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-animation-state/-/react-use-animation-state-2.1.0.tgz",
+      "integrity": "sha512-CFZkQU3gmDBwhqy0vC1ryf90BVHxVN8cTLpSyCpdmExUEtSEInSCGMydj2fvn7QXsz/za8JNdO2xxgJwxpLMtg==",
+      "dependencies": {
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-callback-ref": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-callback-ref/-/react-use-callback-ref-2.1.0.tgz",
+      "integrity": "sha512-efnJrBtGDa4YaxDzDE90EnKD3Vkh5a1t3w7PhnRQmsphLy3g2UieasoKTlT2Hn118TwDjIv5ZjHJW6HbzXA9wQ==",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-controllable-state": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-controllable-state/-/react-use-controllable-state-2.1.0.tgz",
+      "integrity": "sha512-QR/8fKNokxZUs4PfxjXuwl0fj/d71WPrmLJvEpCTkHjnzu7LnYvzoe2wB867IdooQJL0G1zBxl0Dq+6W1P3jpg==",
+      "dependencies": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-disclosure": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-disclosure/-/react-use-disclosure-2.1.0.tgz",
+      "integrity": "sha512-Ax4pmxA9LBGMyEZJhhUZobg9C0t3qFE4jVF1tGBsrLDcdBeLR9fwOogIPY9Hf0/wqSlAryAimICbr5hkpa5GSw==",
+      "dependencies": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-event-listener": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-event-listener/-/react-use-event-listener-2.1.0.tgz",
+      "integrity": "sha512-U5greryDLS8ISP69DKDsYcsXRtAdnTQT+jjIlRYZ49K/XhUR/AqVZCK5BkR1spTDmO9H8SPhgeNKI70ODuDU/Q==",
+      "dependencies": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-focus-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-effect/-/react-use-focus-effect-2.1.0.tgz",
+      "integrity": "sha512-xzVboNy7J64xveLcxTIJ3jv+lUJKDwRM7Szwn9tNzUIPD94O3qwjV7DDCUzN2490nSYDF4OBMt/wuDBtaR3kUQ==",
+      "dependencies": {
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-focus-on-pointer-down": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-on-pointer-down/-/react-use-focus-on-pointer-down-2.1.0.tgz",
+      "integrity": "sha512-2jzrUZ+aiCG/cfanrolsnSMDykCAbv9EK/4iUyZno6BYb3vziucmvgKuoXbMPAzWNtwUwtuMhkby8rc61Ue+Lg==",
+      "dependencies": {
+        "@chakra-ui/react-use-event-listener": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-interval": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-interval/-/react-use-interval-2.1.0.tgz",
+      "integrity": "sha512-8iWj+I/+A0J08pgEXP1J1flcvhLBHkk0ln7ZvGIyXiEyM6XagOTJpwNhiu+Bmk59t3HoV/VyvyJTa+44sEApuw==",
+      "dependencies": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-latest-ref": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-latest-ref/-/react-use-latest-ref-2.1.0.tgz",
+      "integrity": "sha512-m0kxuIYqoYB0va9Z2aW4xP/5b7BzlDeWwyXCH6QpT2PpW3/281L3hLCm1G0eOUcdVlayqrQqOeD6Mglq+5/xoQ==",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-merge-refs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-merge-refs/-/react-use-merge-refs-2.1.0.tgz",
+      "integrity": "sha512-lERa6AWF1cjEtWSGjxWTaSMvneccnAVH4V4ozh8SYiN9fSPZLlSG3kNxfNzdFvMEhM7dnP60vynF7WjGdTgQbQ==",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-outside-click": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-outside-click/-/react-use-outside-click-2.2.0.tgz",
+      "integrity": "sha512-PNX+s/JEaMneijbgAM4iFL+f3m1ga9+6QK0E5Yh4s8KZJQ/bLwZzdhMz8J/+mL+XEXQ5J0N8ivZN28B82N1kNw==",
+      "dependencies": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-pan-event": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-pan-event/-/react-use-pan-event-2.1.0.tgz",
+      "integrity": "sha512-xmL2qOHiXqfcj0q7ZK5s9UjTh4Gz0/gL9jcWPA6GVf+A0Od5imEDa/Vz+533yQKWiNSm1QGrIj0eJAokc7O4fg==",
+      "dependencies": {
+        "@chakra-ui/event-utils": "2.0.8",
+        "@chakra-ui/react-use-latest-ref": "2.1.0",
+        "framesync": "6.1.2"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-previous": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-previous/-/react-use-previous-2.1.0.tgz",
+      "integrity": "sha512-pjxGwue1hX8AFcmjZ2XfrQtIJgqbTF3Qs1Dy3d1krC77dEsiCUbQ9GzOBfDc8pfd60DrB5N2tg5JyHbypqh0Sg==",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-safe-layout-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-safe-layout-effect/-/react-use-safe-layout-effect-2.1.0.tgz",
+      "integrity": "sha512-Knbrrx/bcPwVS1TorFdzrK/zWA8yuU/eaXDkNj24IrKoRlQrSBFarcgAEzlCHtzuhufP3OULPkELTzz91b0tCw==",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-size": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-size/-/react-use-size-2.1.0.tgz",
+      "integrity": "sha512-tbLqrQhbnqOjzTaMlYytp7wY8BW1JpL78iG7Ru1DlV4EWGiAmXFGvtnEt9HftU0NJ0aJyjgymkxfVGI55/1Z4A==",
+      "dependencies": {
+        "@zag-js/element-size": "0.10.5"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-timeout": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-timeout/-/react-use-timeout-2.1.0.tgz",
+      "integrity": "sha512-cFN0sobKMM9hXUhyCofx3/Mjlzah6ADaEl/AXl5Y+GawB5rgedgAcu2ErAgarEkwvsKdP6c68CKjQ9dmTQlJxQ==",
+      "dependencies": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-update-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-update-effect/-/react-use-update-effect-2.1.0.tgz",
+      "integrity": "sha512-ND4Q23tETaR2Qd3zwCKYOOS1dfssojPLJMLvUtUbW5M9uW1ejYWgGUobeAiOVfSplownG8QYMmHTP86p/v0lbA==",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-utils": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-utils/-/react-utils-2.0.12.tgz",
+      "integrity": "sha512-GbSfVb283+YA3kA8w8xWmzbjNWk14uhNpntnipHCftBibl0lxtQ9YqMFQLwuFOO0U2gYVocszqqDWX+XNKq9hw==",
+      "dependencies": {
+        "@chakra-ui/utils": "2.0.15"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-2.1.0.tgz",
+      "integrity": "sha512-6GEjCJNOm1pS9E7XRvodoVOuSFl82Jio3MGWgmcQrLznjJAhIZVMq85vCQqzGpjjfbHys/UctfdJY75Ctas/Jg==",
+      "dependencies": {
+        "@chakra-ui/form-control": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/shared-utils": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/shared-utils/-/shared-utils-2.0.5.tgz",
+      "integrity": "sha512-4/Wur0FqDov7Y0nCXl7HbHzCg4aq86h+SXdoUeuCMD3dSj7dpsVnStLYhng1vxvlbUnLpdF4oz5Myt3i/a7N3Q=="
+    },
+    "node_modules/@chakra-ui/skeleton": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-2.1.0.tgz",
+      "integrity": "sha512-JNRuMPpdZGd6zFVKjVQ0iusu3tXAdI29n4ZENYwAJEMf/fN0l12sVeirOxkJ7oEL0yOx2AgEYFSKdbcAgfUsAQ==",
+      "dependencies": {
+        "@chakra-ui/media-query": "3.3.0",
+        "@chakra-ui/react-use-previous": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/skip-nav": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/skip-nav/-/skip-nav-2.1.0.tgz",
+      "integrity": "sha512-Hk+FG+vadBSH0/7hwp9LJnLjkO0RPGnx7gBJWI4/SpoJf3e4tZlWYtwGj0toYY4aGKl93jVghuwGbDBEMoHDug==",
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/slider": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-2.1.0.tgz",
+      "integrity": "sha512-lUOBcLMCnFZiA/s2NONXhELJh6sY5WtbRykPtclGfynqqOo47lwWJx+VP7xaeuhDOPcWSSecWc9Y1BfPOCz9cQ==",
+      "dependencies": {
+        "@chakra-ui/number-utils": "2.0.7",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-latest-ref": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-pan-event": "2.1.0",
+        "@chakra-ui/react-use-size": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/spinner": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-2.1.0.tgz",
+      "integrity": "sha512-hczbnoXt+MMv/d3gE+hjQhmkzLiKuoTo42YhUG7Bs9OSv2lg1fZHW1fGNRFP3wTi6OIbD044U1P9HK+AOgFH3g==",
+      "dependencies": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/stat": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-2.1.0.tgz",
+      "integrity": "sha512-sqx0/AdFFZ80dsiM5owmhtQyYl+zON1r+IY0m70I/ABRVy+I3br06xdUhoaxh3tcP7c0O/BQgb+VCfXa9Y34CA==",
+      "dependencies": {
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/stepper": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/stepper/-/stepper-2.3.0.tgz",
+      "integrity": "sha512-q80QX/NLrjJQIlBP1N+Q8GVJb7/HiOpMoK1PlP4denB/KxkU2K8GEjss8U2vklR1XsWJy1fwfj03+66Q78Uk/Q==",
+      "dependencies": {
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/styled-system": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.9.1.tgz",
+      "integrity": "sha512-jhYKBLxwOPi9/bQt9kqV3ELa/4CjmNNruTyXlPp5M0v0+pDMUngPp48mVLoskm9RKZGE0h1qpvj/jZ3K7c7t8w==",
+      "dependencies": {
+        "@chakra-ui/shared-utils": "2.0.5",
+        "csstype": "^3.0.11",
+        "lodash.mergewith": "4.6.2"
+      }
+    },
+    "node_modules/@chakra-ui/switch": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-2.1.0.tgz",
+      "integrity": "sha512-uWHOaIDQdGh+mszxeppj5aYVepbkSK445KZlJJkfr9Bnr6sythTwM63HSufnVDiTEE4uRqegv9jEjZK2JKA+9A==",
+      "dependencies": {
+        "@chakra-ui/checkbox": "2.3.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/system": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-2.6.0.tgz",
+      "integrity": "sha512-MgAFRz9V1pW0dplwWsB99hx49LCC+LsrkMala7KXcP0OvWdrkjw+iu+voBksO3626+glzgIwlZW113Eja+7JEQ==",
+      "dependencies": {
+        "@chakra-ui/color-mode": "2.2.0",
+        "@chakra-ui/object-utils": "2.1.0",
+        "@chakra-ui/react-utils": "2.0.12",
+        "@chakra-ui/styled-system": "2.9.1",
+        "@chakra-ui/theme-utils": "2.0.19",
+        "@chakra-ui/utils": "2.0.15",
+        "react-fast-compare": "3.2.1"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0",
+        "@emotion/styled": "^11.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/table": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-2.1.0.tgz",
+      "integrity": "sha512-o5OrjoHCh5uCLdiUb0Oc0vq9rIAeHSIRScc2ExTC9Qg/uVZl2ygLrjToCaKfaaKl1oQexIeAcZDKvPG8tVkHyQ==",
+      "dependencies": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/tabs": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-2.2.0.tgz",
+      "integrity": "sha512-ulN7McHZ322qlbJXg8S+IwdN8Axh8q0HzYBOHzSdcnVphEytfv9TsfJhN0Hx5yjkpekAzG5fewn33ZdIpIpKyQ==",
+      "dependencies": {
+        "@chakra-ui/clickable": "2.1.0",
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/lazy-utils": "2.0.5",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/tag": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-3.1.0.tgz",
+      "integrity": "sha512-Mn2u828z5HvqEBEG+tUJWe3al5tzN87bK2U0QfThx3+zqWbBCWBSCVfnWRtkNh80m+5a1TekexDAPZqu5G8zdw==",
+      "dependencies": {
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/textarea": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-2.1.0.tgz",
+      "integrity": "sha512-4F7X/lPRsY+sPxYrWGrhh1pBtdnFvVllIOapzAwnjYwsflm+vf6c+9ZgoDWobXsNezJ9fcqN0FTPwaBnDvDQRQ==",
+      "dependencies": {
+        "@chakra-ui/form-control": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/theme": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.2.0.tgz",
+      "integrity": "sha512-q9mppdkhmaBnvOT8REr/lVNNBX/prwm50EzObJ+r+ErVhNQDc55gCFmtr+It3xlcCqmOteG6XUdwRCJz8qzOqg==",
+      "dependencies": {
+        "@chakra-ui/anatomy": "2.2.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/theme-tools": "2.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/styled-system": ">=2.8.0"
+      }
+    },
+    "node_modules/@chakra-ui/theme-tools": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.1.0.tgz",
+      "integrity": "sha512-TKv4trAY8q8+DWdZrpSabTd3SZtZrnzFDwUdzhbWBhFEDEVR3fAkRTPpnPDtf1X9w1YErWn3QAcMACVFz4+vkw==",
+      "dependencies": {
+        "@chakra-ui/anatomy": "2.2.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "color2k": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/styled-system": ">=2.0.0"
+      }
+    },
+    "node_modules/@chakra-ui/theme-utils": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-utils/-/theme-utils-2.0.19.tgz",
+      "integrity": "sha512-UQ+KvozTN86+0oA80rdQd1a++4rm4ulo+DEabkgwNpkK3yaWsucOxkDQpi2sMIMvw5X0oaWvNBZJuVyK7HdOXg==",
+      "dependencies": {
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/styled-system": "2.9.1",
+        "@chakra-ui/theme": "3.2.0",
+        "lodash.mergewith": "4.6.2"
+      }
+    },
+    "node_modules/@chakra-ui/toast": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-7.0.0.tgz",
+      "integrity": "sha512-XQgSnn4DYRgfOBzBvh8GI/AZ7SfrO8wlVSmChfp92Nfmqm7tRDUT9x8ws/iNKAvMRHkhl7fmRjJ39ipeXYrMvA==",
+      "dependencies": {
+        "@chakra-ui/alert": "2.2.0",
+        "@chakra-ui/close-button": "2.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-timeout": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/styled-system": "2.9.1",
+        "@chakra-ui/theme": "3.2.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": "2.6.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/tooltip": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-2.3.0.tgz",
+      "integrity": "sha512-2s23f93YIij1qEDwIK//KtEu4LLYOslhR1cUhDBk/WUzyFR3Ez0Ee+HlqlGEGfGe9x77E6/UXPnSAKKdF/cpsg==",
+      "dependencies": {
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-disclosure": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/transition": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-2.1.0.tgz",
+      "integrity": "sha512-orkT6T/Dt+/+kVwJNy7zwJ+U2xAZ3EU7M3XCs45RBvUnZDr/u9vdmaM/3D/rOpmQJWgQBwKPJleUXrYWUagEDQ==",
+      "dependencies": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "framer-motion": ">=4.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/utils": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.0.15.tgz",
+      "integrity": "sha512-El4+jL0WSaYYs+rJbuYFDbjmfCcfGDmRY95GO4xwzit6YAPZBLcR65rOEwLps+XWluZTy1xdMrusg/hW0c1aAA==",
+      "dependencies": {
+        "@types/lodash.mergewith": "4.6.7",
+        "css-box-model": "1.2.1",
+        "framesync": "6.1.2",
+        "lodash.mergewith": "4.6.2"
+      }
+    },
+    "node_modules/@chakra-ui/visually-hidden": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-2.1.0.tgz",
+      "integrity": "sha512-3OHKqTz78PX7V4qto+a5Y6VvH6TbU3Pg6Z0Z2KnDkOBP3Po8fiz0kk+/OSPzIwdcSsQKiocLi0c1pnnUPdMZPg==",
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
     "node_modules/@csstools/normalize.css": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
@@ -2272,6 +3449,158 @@
       "peerDependencies": {
         "postcss-selector-parser": "^6.0.10"
       }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
+      "integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.1",
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/serialize": "^1.1.2",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
+      "integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/sheet": "^1.2.2",
+        "@emotion/utils": "^1.2.1",
+        "@emotion/weak-memoize": "^0.3.1",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
+      "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.1"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.1.tgz",
+      "integrity": "sha512-5mlW1DquU5HaxjLkfkGN1GA/fvVGdyHURRiX/0FHl2cfIfRxSOfmxEH5YS43edp0OldZrZ+dkBKbngxcNCdZvA==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.11.0",
+        "@emotion/cache": "^11.11.0",
+        "@emotion/serialize": "^1.1.2",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+        "@emotion/utils": "^1.2.1",
+        "@emotion/weak-memoize": "^0.3.1",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.2.tgz",
+      "integrity": "sha512-zR6a/fkFP4EAcCMQtLOhIgpprZOwNmCldtpaISpvz348+DP4Mz8ZoKaGGCQpbzepNIUWbq4w6hNZkwDyKoS+HA==",
+      "dependencies": {
+        "@emotion/hash": "^0.9.1",
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/unitless": "^0.8.1",
+        "@emotion/utils": "^1.2.1",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
+      "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.0.tgz",
+      "integrity": "sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.11.0",
+        "@emotion/is-prop-valid": "^1.2.1",
+        "@emotion/serialize": "^1.1.2",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+        "@emotion/utils": "^1.2.1"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
+      "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
+      "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
+      "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -3225,6 +4554,15 @@
         }
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "1.9.5",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.5.tgz",
@@ -4080,6 +5418,19 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
+    "node_modules/@types/lodash": {
+      "version": "4.14.197",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.197.tgz",
+      "integrity": "sha512-BMVOiWs0uNxHVlHBgzTIqJYmj+PgCo4euloGF+5m4okL3rEYzM2EEv78mw8zWSMM57dM7kVIgJ2QDvwHSoCI5g=="
+    },
+    "node_modules/@types/lodash.mergewith": {
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.7.tgz",
+      "integrity": "sha512-3m+lkO5CLRRYU0fhGRp7zbsGi6+BZj0uTVSwvcKU+nSlhjA9/QRNfuSGnD2mX6hQA7ZbmcCkzk5h4ZYGOtk14A==",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -4599,6 +5950,24 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
+    "node_modules/@zag-js/dom-query": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.10.5.tgz",
+      "integrity": "sha512-zm6wA5+kqU48it6afNjaUhjVSixKZruTKB23z0V1xBqKbuiLOMMOZ5oK26cTPSXtZ5CPhDNZ2Qk4pliS5n9SVw=="
+    },
+    "node_modules/@zag-js/element-size": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@zag-js/element-size/-/element-size-0.10.5.tgz",
+      "integrity": "sha512-uQre5IidULANvVkNOBQ1tfgwTQcGl4hliPSe69Fct1VfYb2Fd0jdAcGzqQgPhfrXFpR62MxLPB7erxJ/ngtL8w=="
+    },
+    "node_modules/@zag-js/focus-visible": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-0.10.5.tgz",
+      "integrity": "sha512-EhDHKLutMtvLFCjBjyIY6h1JoJJNXG3KJz7Dj1sh4tj4LWAqo/TqLvgHyUTB29XMHwoslFHDJHKVWmLGMi+ULQ==",
+      "dependencies": {
+        "@zag-js/dom-query": "0.10.5"
+      }
+    },
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -4833,6 +6202,17 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
+      "integrity": "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/aria-query": {
@@ -5838,6 +7218,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
+    "node_modules/color2k": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.2.tgz",
+      "integrity": "sha512-kJhwH5nAwb34tmyuqq/lgjEKzlFXn1U99NlnB6Ws4qVaERcRUYeYP1cBw6BJ4vxaWStAUEef4WMr7WjOCnBt8w=="
+    },
     "node_modules/colord": {
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
@@ -5931,6 +7316,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "node_modules/compute-scroll-into-view": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
+      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5985,6 +7375,14 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
     },
     "node_modules/core-js": {
       "version": "3.32.0",
@@ -6074,6 +7472,14 @@
       },
       "peerDependencies": {
         "postcss": "^8.4"
+      }
+    },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "node_modules/css-declaration-sorter": {
@@ -6618,6 +8024,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "node_modules/detect-port-alt": {
       "version": "1.1.6",
@@ -8076,6 +9487,11 @@
         "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -8107,6 +9523,17 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
+    },
+    "node_modules/focus-lock": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.6.tgz",
+      "integrity": "sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.2",
@@ -8324,6 +9751,57 @@
         "url": "https://www.patreon.com/infusion"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "10.16.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.16.0.tgz",
+      "integrity": "sha512-R+88Mkr/1dr7XHjacwptfJyrywRzQ1HZX3YSZtN4tFMBq1O8GGCbDEv31Nf/H08o0hUXLC87GkxsR/1bZgwXfw==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/framer-motion/node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "optional": true,
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "node_modules/framer-motion/node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "optional": true
+    },
+    "node_modules/framesync": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.1.2.tgz",
+      "integrity": "sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==",
+      "dependencies": {
+        "tslib": "2.4.0"
+      }
+    },
+    "node_modules/framesync/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -8426,6 +9904,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-own-enumerable-property-symbols": {
@@ -9096,6 +10582,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/ipaddr.js": {
@@ -11897,6 +13391,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
+    },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -14323,6 +15822,17 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
+    "node_modules/react-clientside-effect": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
+      "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -14457,6 +15967,33 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.1.tgz",
+      "integrity": "sha512-xTYf9zFim2pEif/Fw16dBiXpe0hoy5PxcD8+OwBnTtNLfIm3g6WxhKNurY+6OmdH1u6Ta/W/Vl6vjbYP1MFnDg=="
+    },
+    "node_modules/react-focus-lock": {
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.5.tgz",
+      "integrity": "sha512-h6vrdgUbsH2HeD5I7I3Cx1PPrmwGuKYICS+kB9m+32X/9xHRrAbxgvaBpG7BFBN9h3tO+C3qX1QAVESmi4CiIA==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^0.11.6",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.6",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -14511,6 +16048,51 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.6.tgz",
+      "integrity": "sha512-bO856ad1uDYLefgArk559IzUNeQ6SWH4QnrevIUjH+GczV56giDfl3h0Idptf2oIKxQmd1p9BN25jleKodTALg==",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.4",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
+      "integrity": "sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==",
+      "dependencies": {
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-scripts": {
@@ -14581,6 +16163,28 @@
       },
       "peerDependenciesMeta": {
         "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -15765,6 +17369,11 @@
         "postcss": "^8.2.15"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
+    },
     "node_modules/sucrase": {
       "version": "3.34.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.34.0.tgz",
@@ -16153,6 +17762,11 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -16176,6 +17790,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -16540,6 +18159,47 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {
@@ -18890,6 +20550,900 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
+    "@chakra-ui/accordion": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-2.3.0.tgz",
+      "integrity": "sha512-A4TkRw3Jnt+Fam6dSSJ62rskdrvjF3JGctYcfXlojfFIpHPuIw4pDwfZgNAxlaxWkcj0e7JJKlQ88dnZW+QfFg==",
+      "requires": {
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/transition": "2.1.0"
+      }
+    },
+    "@chakra-ui/alert": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-2.2.0.tgz",
+      "integrity": "sha512-De+BT88iYOu3Con7MxQeICb1SwgAdVdgpHIYjTh3qvGlNXAQjs81rhG0fONXvwW1FIYletvr9DY2Tlg8xJe7tQ==",
+      "requires": {
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/spinner": "2.1.0"
+      }
+    },
+    "@chakra-ui/anatomy": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.2.0.tgz",
+      "integrity": "sha512-cD8Ms5C8+dFda0LrORMdxiFhAZwOIY1BSlCadz6/mHUIgNdQy13AHPrXiq6qWdMslqVHq10k5zH7xMPLt6kjFg=="
+    },
+    "@chakra-ui/avatar": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-2.3.0.tgz",
+      "integrity": "sha512-8gKSyLfygnaotbJbDMHDiJoF38OHXUYVme4gGxZ1fLnQEdPVEaIWfH+NndIjOM0z8S+YEFnT9KyGMUtvPrBk3g==",
+      "requires": {
+        "@chakra-ui/image": "2.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/breadcrumb": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-2.2.0.tgz",
+      "integrity": "sha512-4cWCG24flYBxjruRi4RJREWTGF74L/KzI2CognAW/d/zWR0CjiScuJhf37Am3LFbCySP6WSoyBOtTIoTA4yLEA==",
+      "requires": {
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/breakpoint-utils": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/breakpoint-utils/-/breakpoint-utils-2.0.8.tgz",
+      "integrity": "sha512-Pq32MlEX9fwb5j5xx8s18zJMARNHlQZH2VH1RZgfgRDpp7DcEgtRW5AInfN5CfqdHLO1dGxA7I3MqEuL5JnIsA==",
+      "requires": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/button": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-2.1.0.tgz",
+      "integrity": "sha512-95CplwlRKmmUXkdEp/21VkEWgnwcx2TOBG6NfYlsuLBDHSLlo5FKIiE2oSi4zXc4TLcopGcWPNcm/NDaSC5pvA==",
+      "requires": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/spinner": "2.1.0"
+      }
+    },
+    "@chakra-ui/card": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/card/-/card-2.2.0.tgz",
+      "integrity": "sha512-xUB/k5MURj4CtPAhdSoXZidUbm8j3hci9vnc+eZJVDqhDOShNlD6QeniQNRPRys4lWAQLCbFcrwL29C8naDi6g==",
+      "requires": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/checkbox": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-2.3.0.tgz",
+      "integrity": "sha512-fX7M5sQK27aFWoj7vqnPkf1Q3AHmML/5dIRYfm7HEIsZXYH2C1CkM6+dijeSWIk6a0mp0r3el6SNDUti2ehH8g==",
+      "requires": {
+        "@chakra-ui/form-control": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/visually-hidden": "2.1.0",
+        "@zag-js/focus-visible": "0.10.5"
+      }
+    },
+    "@chakra-ui/clickable": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-2.1.0.tgz",
+      "integrity": "sha512-flRA/ClPUGPYabu+/GLREZVZr9j2uyyazCAUHAdrTUEdDYCr31SVGhgh7dgKdtq23bOvAQJpIJjw/0Bs0WvbXw==",
+      "requires": {
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/close-button": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/close-button/-/close-button-2.1.0.tgz",
+      "integrity": "sha512-KfJcz6UAaR2dDWSIv6UrCGkZQS54Fjl+DEEVOUTJ7gf4KOP4FQZCkv8hqsAB9FeCtnwU43adq2oaw3aZH/Uzew==",
+      "requires": {
+        "@chakra-ui/icon": "3.1.0"
+      }
+    },
+    "@chakra-ui/color-mode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/color-mode/-/color-mode-2.2.0.tgz",
+      "integrity": "sha512-niTEA8PALtMWRI9wJ4LL0CSBDo8NBfLNp4GD6/0hstcm3IlbBHTVKxN6HwSaoNYfphDQLxCjT4yG+0BJA5tFpg==",
+      "requires": {
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
+      }
+    },
+    "@chakra-ui/control-box": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-2.1.0.tgz",
+      "integrity": "sha512-gVrRDyXFdMd8E7rulL0SKeoljkLQiPITFnsyMO8EFHNZ+AHt5wK4LIguYVEq88APqAGZGfHFWXr79RYrNiE3Mg==",
+      "requires": {}
+    },
+    "@chakra-ui/counter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-2.1.0.tgz",
+      "integrity": "sha512-s6hZAEcWT5zzjNz2JIWUBzRubo9la/oof1W7EKZVVfPYHERnl5e16FmBC79Yfq8p09LQ+aqFKm/etYoJMMgghw==",
+      "requires": {
+        "@chakra-ui/number-utils": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/css-reset": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/css-reset/-/css-reset-2.2.0.tgz",
+      "integrity": "sha512-nn7hjquIrPwCzwI4d/Y4wzM5A5xAeswREOfT8gT0Yd+U+Qnw3pPT8NPLbNJ3DvuOfJaCV6/N5ld/6RRTgYF/sQ==",
+      "requires": {}
+    },
+    "@chakra-ui/descendant": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/descendant/-/descendant-3.1.0.tgz",
+      "integrity": "sha512-VxCIAir08g5w27klLyi7PVo8BxhW4tgU/lxQyujkmi4zx7hT9ZdrcQLAted/dAa+aSIZ14S1oV0Q9lGjsAdxUQ==",
+      "requires": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0"
+      }
+    },
+    "@chakra-ui/dom-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/dom-utils/-/dom-utils-2.1.0.tgz",
+      "integrity": "sha512-ZmF2qRa1QZ0CMLU8M1zCfmw29DmPNtfjR9iTo74U5FPr3i1aoAh7fbJ4qAlZ197Xw9eAW28tvzQuoVWeL5C7fQ=="
+    },
+    "@chakra-ui/editable": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-3.1.0.tgz",
+      "integrity": "sha512-j2JLrUL9wgg4YA6jLlbU88370eCRyor7DZQD9lzpY95tSOXpTljeg3uF9eOmDnCs6fxp3zDWIfkgMm/ExhcGTg==",
+      "requires": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-focus-on-pointer-down": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/event-utils": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/event-utils/-/event-utils-2.0.8.tgz",
+      "integrity": "sha512-IGM/yGUHS+8TOQrZGpAKOJl/xGBrmRYJrmbHfUE7zrG3PpQyXvbLDP1M+RggkCFVgHlJi2wpYIf0QtQlU0XZfw=="
+    },
+    "@chakra-ui/focus-lock": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-2.1.0.tgz",
+      "integrity": "sha512-EmGx4PhWGjm4dpjRqM4Aa+rCWBxP+Rq8Uc/nAVnD4YVqkEhBkrPTpui2lnjsuxqNaZ24fIAZ10cF1hlpemte/w==",
+      "requires": {
+        "@chakra-ui/dom-utils": "2.1.0",
+        "react-focus-lock": "^2.9.4"
+      }
+    },
+    "@chakra-ui/form-control": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/form-control/-/form-control-2.1.0.tgz",
+      "integrity": "sha512-3QmWG9v6Rx+JOwJP3Wt89+AWZxK0F1NkVAgXP3WVfE9VDXOKFRV/faLT0GEe2V+l7WZHF5PLdEBvKG8Cgw2mkA==",
+      "requires": {
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/hooks": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-2.2.0.tgz",
+      "integrity": "sha512-GZE64mcr20w+3KbCUPqQJHHmiFnX5Rcp8jS3YntGA4D5X2qU85jka7QkjfBwv/iduZ5Ei0YpCMYGCpi91dhD1Q==",
+      "requires": {
+        "@chakra-ui/react-utils": "2.0.12",
+        "@chakra-ui/utils": "2.0.15",
+        "compute-scroll-into-view": "1.0.20",
+        "copy-to-clipboard": "3.3.3"
+      }
+    },
+    "@chakra-ui/icon": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-3.1.0.tgz",
+      "integrity": "sha512-t6v0lGCXRbwUJycN8A/nDTuLktMP+LRjKbYJnd2oL6Pm2vOl99XwEQ5cAEyEa4XoseYNEgXiLR+2TfvgfNFvcw==",
+      "requires": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/icons": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.1.0.tgz",
+      "integrity": "sha512-pGFxFfQ/P5VnSRnTzK8zGAJxoxkxpHo/Br9ohRZdOpuhnIHSW7va0P53UoycEO5/vNJ/7BN0oDY0k9qurChcew==",
+      "requires": {
+        "@chakra-ui/icon": "3.1.0"
+      }
+    },
+    "@chakra-ui/image": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-2.1.0.tgz",
+      "integrity": "sha512-bskumBYKLiLMySIWDGcz0+D9Th0jPvmX6xnRMs4o92tT3Od/bW26lahmV2a2Op2ItXeCmRMY+XxJH5Gy1i46VA==",
+      "requires": {
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/input": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-2.1.0.tgz",
+      "integrity": "sha512-HItI2vq6vupCuixdzof4sIanGdLlszhDtlR5be5z8Nrda1RkXVqI+9CTJPbNsx2nIKEfwPt01pnT9mozoOSMMw==",
+      "requires": {
+        "@chakra-ui/form-control": "2.1.0",
+        "@chakra-ui/object-utils": "2.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/layout": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-2.3.0.tgz",
+      "integrity": "sha512-tp1/Bn+cHn0Q4HWKY62HtOwzhpH1GUA3i5fvs23HEhOEryTps05hyuQVeJ71fLqSs6f1QEIdm+9It+5WCj64vQ==",
+      "requires": {
+        "@chakra-ui/breakpoint-utils": "2.0.8",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/object-utils": "2.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/lazy-utils": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/lazy-utils/-/lazy-utils-2.0.5.tgz",
+      "integrity": "sha512-UULqw7FBvcckQk2n3iPO56TMJvDsNv0FKZI6PlUNJVaGsPbsYxK/8IQ60vZgaTVPtVcjY6BE+y6zg8u9HOqpyg=="
+    },
+    "@chakra-ui/live-region": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-2.1.0.tgz",
+      "integrity": "sha512-ZOxFXwtaLIsXjqnszYYrVuswBhnIHHP+XIgK1vC6DePKtyK590Wg+0J0slDwThUAd4MSSIUa/nNX84x1GMphWw==",
+      "requires": {}
+    },
+    "@chakra-ui/media-query": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-3.3.0.tgz",
+      "integrity": "sha512-IsTGgFLoICVoPRp9ykOgqmdMotJG0CnPsKvGQeSFOB/dZfIujdVb14TYxDU4+MURXry1MhJ7LzZhv+Ml7cr8/g==",
+      "requires": {
+        "@chakra-ui/breakpoint-utils": "2.0.8",
+        "@chakra-ui/react-env": "3.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/menu": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-2.2.0.tgz",
+      "integrity": "sha512-l7HQjriW4JGeCyxDdguAzekwwB+kHGDLxACi0DJNp37sil51SRaN1S1OrneISbOHVpHuQB+KVNgU0rqhoglVew==",
+      "requires": {
+        "@chakra-ui/clickable": "2.1.0",
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/lazy-utils": "2.0.5",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-animation-state": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-disclosure": "2.1.0",
+        "@chakra-ui/react-use-focus-effect": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-outside-click": "2.2.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/transition": "2.1.0"
+      }
+    },
+    "@chakra-ui/modal": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-2.3.0.tgz",
+      "integrity": "sha512-S1sITrIeLSf21LJ0Vz8xZhj5fWEud5z5Dl2dmvOEv1ezypgOrCCBdOEnnqCkoEKZDbKvzZWZXWR5791ikLP6+g==",
+      "requires": {
+        "@chakra-ui/close-button": "2.1.0",
+        "@chakra-ui/focus-lock": "2.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/transition": "2.1.0",
+        "aria-hidden": "^1.2.2",
+        "react-remove-scroll": "^2.5.5"
+      }
+    },
+    "@chakra-ui/number-input": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-2.1.0.tgz",
+      "integrity": "sha512-/gEAzQHhrMA+1rzyCMaN8OkKtUPuER6iA+nloYEYBoT7dH/EoNlRtBkiIQhDp+E4VpgZJ0SK3OVrm9/eBbtHHg==",
+      "requires": {
+        "@chakra-ui/counter": "2.1.0",
+        "@chakra-ui/form-control": "2.1.0",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-interval": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/number-utils": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/number-utils/-/number-utils-2.0.7.tgz",
+      "integrity": "sha512-yOGxBjXNvLTBvQyhMDqGU0Oj26s91mbAlqKHiuw737AXHt0aPllOthVUqQMeaYLwLCjGMg0jtI7JReRzyi94Dg=="
+    },
+    "@chakra-ui/object-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/object-utils/-/object-utils-2.1.0.tgz",
+      "integrity": "sha512-tgIZOgLHaoti5PYGPTwK3t/cqtcycW0owaiOXoZOcpwwX/vlVb+H1jFsQyWiiwQVPt9RkoSLtxzXamx+aHH+bQ=="
+    },
+    "@chakra-ui/pin-input": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-2.1.0.tgz",
+      "integrity": "sha512-x4vBqLStDxJFMt+jdAHHS8jbh294O53CPQJoL4g228P513rHylV/uPscYUHrVJXRxsHfRztQO9k45jjTYaPRMw==",
+      "requires": {
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/popover": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-2.2.0.tgz",
+      "integrity": "sha512-cTqXdgkU0vgK82AR1nWcC2MJYhEL/y6uTeprvO2+j4o2D0yPrzVMuIZZRl0abrQwiravQyVGEMgA5y0ZLYwbiQ==",
+      "requires": {
+        "@chakra-ui/close-button": "2.1.0",
+        "@chakra-ui/lazy-utils": "2.0.5",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-animation-state": "2.1.0",
+        "@chakra-ui/react-use-disclosure": "2.1.0",
+        "@chakra-ui/react-use-focus-effect": "2.1.0",
+        "@chakra-ui/react-use-focus-on-pointer-down": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/popper": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popper/-/popper-3.1.0.tgz",
+      "integrity": "sha512-ciDdpdYbeFG7og6/6J8lkTFxsSvwTdMLFkpVylAF6VNC22jssiWfquj2eyD4rJnzkRFPvIWJq8hvbfhsm+AjSg==",
+      "requires": {
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@popperjs/core": "^2.9.3"
+      }
+    },
+    "@chakra-ui/portal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/portal/-/portal-2.1.0.tgz",
+      "integrity": "sha512-9q9KWf6SArEcIq1gGofNcFPSWEyl+MfJjEUg/un1SMlQjaROOh3zYr+6JAwvcORiX7tyHosnmWC3d3wI2aPSQg==",
+      "requires": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
+      }
+    },
+    "@chakra-ui/progress": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-2.2.0.tgz",
+      "integrity": "sha512-qUXuKbuhN60EzDD9mHR7B67D7p/ZqNS2Aze4Pbl1qGGZfulPW0PY8Rof32qDtttDQBkzQIzFGE8d9QpAemToIQ==",
+      "requires": {
+        "@chakra-ui/react-context": "2.1.0"
+      }
+    },
+    "@chakra-ui/provider": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/provider/-/provider-2.4.0.tgz",
+      "integrity": "sha512-KJ/TNczpY+EStQXa2Y5PZ+senlBHrY7P+RpBgJLBZLGkQUCS3APw5KvCwgpA0COb2M4AZXCjw+rm+Ko7ontlgA==",
+      "requires": {
+        "@chakra-ui/css-reset": "2.2.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-env": "3.1.0",
+        "@chakra-ui/system": "2.6.0",
+        "@chakra-ui/utils": "2.0.15"
+      }
+    },
+    "@chakra-ui/radio": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-2.1.0.tgz",
+      "integrity": "sha512-WiRlSCqKWgy4m9106w4g77kcLYqBxqGhFRO1pTTJp99rxpM6jNadOeK+moEjqj64N9mSz3njEecMJftKKcOYdg==",
+      "requires": {
+        "@chakra-ui/form-control": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@zag-js/focus-visible": "0.10.5"
+      }
+    },
+    "@chakra-ui/react": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.8.0.tgz",
+      "integrity": "sha512-tV82DaqE4fMbLIWq58BYh4Ol3gAlNEn+qYOzx8bPrZudboEDnboq8aVfSBwWOY++MLWz2Nn7CkT69YRm91e5sg==",
+      "requires": {
+        "@chakra-ui/accordion": "2.3.0",
+        "@chakra-ui/alert": "2.2.0",
+        "@chakra-ui/avatar": "2.3.0",
+        "@chakra-ui/breadcrumb": "2.2.0",
+        "@chakra-ui/button": "2.1.0",
+        "@chakra-ui/card": "2.2.0",
+        "@chakra-ui/checkbox": "2.3.0",
+        "@chakra-ui/close-button": "2.1.0",
+        "@chakra-ui/control-box": "2.1.0",
+        "@chakra-ui/counter": "2.1.0",
+        "@chakra-ui/css-reset": "2.2.0",
+        "@chakra-ui/editable": "3.1.0",
+        "@chakra-ui/focus-lock": "2.1.0",
+        "@chakra-ui/form-control": "2.1.0",
+        "@chakra-ui/hooks": "2.2.0",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/image": "2.1.0",
+        "@chakra-ui/input": "2.1.0",
+        "@chakra-ui/layout": "2.3.0",
+        "@chakra-ui/live-region": "2.1.0",
+        "@chakra-ui/media-query": "3.3.0",
+        "@chakra-ui/menu": "2.2.0",
+        "@chakra-ui/modal": "2.3.0",
+        "@chakra-ui/number-input": "2.1.0",
+        "@chakra-ui/pin-input": "2.1.0",
+        "@chakra-ui/popover": "2.2.0",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/progress": "2.2.0",
+        "@chakra-ui/provider": "2.4.0",
+        "@chakra-ui/radio": "2.1.0",
+        "@chakra-ui/react-env": "3.1.0",
+        "@chakra-ui/select": "2.1.0",
+        "@chakra-ui/skeleton": "2.1.0",
+        "@chakra-ui/skip-nav": "2.1.0",
+        "@chakra-ui/slider": "2.1.0",
+        "@chakra-ui/spinner": "2.1.0",
+        "@chakra-ui/stat": "2.1.0",
+        "@chakra-ui/stepper": "2.3.0",
+        "@chakra-ui/styled-system": "2.9.1",
+        "@chakra-ui/switch": "2.1.0",
+        "@chakra-ui/system": "2.6.0",
+        "@chakra-ui/table": "2.1.0",
+        "@chakra-ui/tabs": "2.2.0",
+        "@chakra-ui/tag": "3.1.0",
+        "@chakra-ui/textarea": "2.1.0",
+        "@chakra-ui/theme": "3.2.0",
+        "@chakra-ui/theme-utils": "2.0.19",
+        "@chakra-ui/toast": "7.0.0",
+        "@chakra-ui/tooltip": "2.3.0",
+        "@chakra-ui/transition": "2.1.0",
+        "@chakra-ui/utils": "2.0.15",
+        "@chakra-ui/visually-hidden": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-children-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-children-utils/-/react-children-utils-2.0.6.tgz",
+      "integrity": "sha512-QVR2RC7QsOsbWwEnq9YduhpqSFnZGvjjGREV8ygKi8ADhXh93C8azLECCUVgRJF2Wc+So1fgxmjLcbZfY2VmBA==",
+      "requires": {}
+    },
+    "@chakra-ui/react-context": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-context/-/react-context-2.1.0.tgz",
+      "integrity": "sha512-iahyStvzQ4AOwKwdPReLGfDesGG+vWJfEsn0X/NoGph/SkN+HXtv2sCfYFFR9k7bb+Kvc6YfpLlSuLvKMHi2+w==",
+      "requires": {}
+    },
+    "@chakra-ui/react-env": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-3.1.0.tgz",
+      "integrity": "sha512-Vr96GV2LNBth3+IKzr/rq1IcnkXv+MLmwjQH6C8BRtn3sNskgDFD5vLkVXcEhagzZMCh8FR3V/bzZPojBOyNhw==",
+      "requires": {
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-types/-/react-types-2.0.7.tgz",
+      "integrity": "sha512-12zv2qIZ8EHwiytggtGvo4iLT0APris7T0qaAWqzpUGS0cdUtR8W+V1BJ5Ocq+7tA6dzQ/7+w5hmXih61TuhWQ==",
+      "requires": {}
+    },
+    "@chakra-ui/react-use-animation-state": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-animation-state/-/react-use-animation-state-2.1.0.tgz",
+      "integrity": "sha512-CFZkQU3gmDBwhqy0vC1ryf90BVHxVN8cTLpSyCpdmExUEtSEInSCGMydj2fvn7QXsz/za8JNdO2xxgJwxpLMtg==",
+      "requires": {
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-callback-ref": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-callback-ref/-/react-use-callback-ref-2.1.0.tgz",
+      "integrity": "sha512-efnJrBtGDa4YaxDzDE90EnKD3Vkh5a1t3w7PhnRQmsphLy3g2UieasoKTlT2Hn118TwDjIv5ZjHJW6HbzXA9wQ==",
+      "requires": {}
+    },
+    "@chakra-ui/react-use-controllable-state": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-controllable-state/-/react-use-controllable-state-2.1.0.tgz",
+      "integrity": "sha512-QR/8fKNokxZUs4PfxjXuwl0fj/d71WPrmLJvEpCTkHjnzu7LnYvzoe2wB867IdooQJL0G1zBxl0Dq+6W1P3jpg==",
+      "requires": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-disclosure": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-disclosure/-/react-use-disclosure-2.1.0.tgz",
+      "integrity": "sha512-Ax4pmxA9LBGMyEZJhhUZobg9C0t3qFE4jVF1tGBsrLDcdBeLR9fwOogIPY9Hf0/wqSlAryAimICbr5hkpa5GSw==",
+      "requires": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-event-listener": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-event-listener/-/react-use-event-listener-2.1.0.tgz",
+      "integrity": "sha512-U5greryDLS8ISP69DKDsYcsXRtAdnTQT+jjIlRYZ49K/XhUR/AqVZCK5BkR1spTDmO9H8SPhgeNKI70ODuDU/Q==",
+      "requires": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-focus-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-effect/-/react-use-focus-effect-2.1.0.tgz",
+      "integrity": "sha512-xzVboNy7J64xveLcxTIJ3jv+lUJKDwRM7Szwn9tNzUIPD94O3qwjV7DDCUzN2490nSYDF4OBMt/wuDBtaR3kUQ==",
+      "requires": {
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-focus-on-pointer-down": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-on-pointer-down/-/react-use-focus-on-pointer-down-2.1.0.tgz",
+      "integrity": "sha512-2jzrUZ+aiCG/cfanrolsnSMDykCAbv9EK/4iUyZno6BYb3vziucmvgKuoXbMPAzWNtwUwtuMhkby8rc61Ue+Lg==",
+      "requires": {
+        "@chakra-ui/react-use-event-listener": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-interval": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-interval/-/react-use-interval-2.1.0.tgz",
+      "integrity": "sha512-8iWj+I/+A0J08pgEXP1J1flcvhLBHkk0ln7ZvGIyXiEyM6XagOTJpwNhiu+Bmk59t3HoV/VyvyJTa+44sEApuw==",
+      "requires": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-latest-ref": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-latest-ref/-/react-use-latest-ref-2.1.0.tgz",
+      "integrity": "sha512-m0kxuIYqoYB0va9Z2aW4xP/5b7BzlDeWwyXCH6QpT2PpW3/281L3hLCm1G0eOUcdVlayqrQqOeD6Mglq+5/xoQ==",
+      "requires": {}
+    },
+    "@chakra-ui/react-use-merge-refs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-merge-refs/-/react-use-merge-refs-2.1.0.tgz",
+      "integrity": "sha512-lERa6AWF1cjEtWSGjxWTaSMvneccnAVH4V4ozh8SYiN9fSPZLlSG3kNxfNzdFvMEhM7dnP60vynF7WjGdTgQbQ==",
+      "requires": {}
+    },
+    "@chakra-ui/react-use-outside-click": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-outside-click/-/react-use-outside-click-2.2.0.tgz",
+      "integrity": "sha512-PNX+s/JEaMneijbgAM4iFL+f3m1ga9+6QK0E5Yh4s8KZJQ/bLwZzdhMz8J/+mL+XEXQ5J0N8ivZN28B82N1kNw==",
+      "requires": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-pan-event": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-pan-event/-/react-use-pan-event-2.1.0.tgz",
+      "integrity": "sha512-xmL2qOHiXqfcj0q7ZK5s9UjTh4Gz0/gL9jcWPA6GVf+A0Od5imEDa/Vz+533yQKWiNSm1QGrIj0eJAokc7O4fg==",
+      "requires": {
+        "@chakra-ui/event-utils": "2.0.8",
+        "@chakra-ui/react-use-latest-ref": "2.1.0",
+        "framesync": "6.1.2"
+      }
+    },
+    "@chakra-ui/react-use-previous": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-previous/-/react-use-previous-2.1.0.tgz",
+      "integrity": "sha512-pjxGwue1hX8AFcmjZ2XfrQtIJgqbTF3Qs1Dy3d1krC77dEsiCUbQ9GzOBfDc8pfd60DrB5N2tg5JyHbypqh0Sg==",
+      "requires": {}
+    },
+    "@chakra-ui/react-use-safe-layout-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-safe-layout-effect/-/react-use-safe-layout-effect-2.1.0.tgz",
+      "integrity": "sha512-Knbrrx/bcPwVS1TorFdzrK/zWA8yuU/eaXDkNj24IrKoRlQrSBFarcgAEzlCHtzuhufP3OULPkELTzz91b0tCw==",
+      "requires": {}
+    },
+    "@chakra-ui/react-use-size": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-size/-/react-use-size-2.1.0.tgz",
+      "integrity": "sha512-tbLqrQhbnqOjzTaMlYytp7wY8BW1JpL78iG7Ru1DlV4EWGiAmXFGvtnEt9HftU0NJ0aJyjgymkxfVGI55/1Z4A==",
+      "requires": {
+        "@zag-js/element-size": "0.10.5"
+      }
+    },
+    "@chakra-ui/react-use-timeout": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-timeout/-/react-use-timeout-2.1.0.tgz",
+      "integrity": "sha512-cFN0sobKMM9hXUhyCofx3/Mjlzah6ADaEl/AXl5Y+GawB5rgedgAcu2ErAgarEkwvsKdP6c68CKjQ9dmTQlJxQ==",
+      "requires": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-update-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-update-effect/-/react-use-update-effect-2.1.0.tgz",
+      "integrity": "sha512-ND4Q23tETaR2Qd3zwCKYOOS1dfssojPLJMLvUtUbW5M9uW1ejYWgGUobeAiOVfSplownG8QYMmHTP86p/v0lbA==",
+      "requires": {}
+    },
+    "@chakra-ui/react-utils": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-utils/-/react-utils-2.0.12.tgz",
+      "integrity": "sha512-GbSfVb283+YA3kA8w8xWmzbjNWk14uhNpntnipHCftBibl0lxtQ9YqMFQLwuFOO0U2gYVocszqqDWX+XNKq9hw==",
+      "requires": {
+        "@chakra-ui/utils": "2.0.15"
+      }
+    },
+    "@chakra-ui/select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-2.1.0.tgz",
+      "integrity": "sha512-6GEjCJNOm1pS9E7XRvodoVOuSFl82Jio3MGWgmcQrLznjJAhIZVMq85vCQqzGpjjfbHys/UctfdJY75Ctas/Jg==",
+      "requires": {
+        "@chakra-ui/form-control": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/shared-utils": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/shared-utils/-/shared-utils-2.0.5.tgz",
+      "integrity": "sha512-4/Wur0FqDov7Y0nCXl7HbHzCg4aq86h+SXdoUeuCMD3dSj7dpsVnStLYhng1vxvlbUnLpdF4oz5Myt3i/a7N3Q=="
+    },
+    "@chakra-ui/skeleton": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-2.1.0.tgz",
+      "integrity": "sha512-JNRuMPpdZGd6zFVKjVQ0iusu3tXAdI29n4ZENYwAJEMf/fN0l12sVeirOxkJ7oEL0yOx2AgEYFSKdbcAgfUsAQ==",
+      "requires": {
+        "@chakra-ui/media-query": "3.3.0",
+        "@chakra-ui/react-use-previous": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/skip-nav": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/skip-nav/-/skip-nav-2.1.0.tgz",
+      "integrity": "sha512-Hk+FG+vadBSH0/7hwp9LJnLjkO0RPGnx7gBJWI4/SpoJf3e4tZlWYtwGj0toYY4aGKl93jVghuwGbDBEMoHDug==",
+      "requires": {}
+    },
+    "@chakra-ui/slider": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-2.1.0.tgz",
+      "integrity": "sha512-lUOBcLMCnFZiA/s2NONXhELJh6sY5WtbRykPtclGfynqqOo47lwWJx+VP7xaeuhDOPcWSSecWc9Y1BfPOCz9cQ==",
+      "requires": {
+        "@chakra-ui/number-utils": "2.0.7",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-latest-ref": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-pan-event": "2.1.0",
+        "@chakra-ui/react-use-size": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0"
+      }
+    },
+    "@chakra-ui/spinner": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-2.1.0.tgz",
+      "integrity": "sha512-hczbnoXt+MMv/d3gE+hjQhmkzLiKuoTo42YhUG7Bs9OSv2lg1fZHW1fGNRFP3wTi6OIbD044U1P9HK+AOgFH3g==",
+      "requires": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/stat": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-2.1.0.tgz",
+      "integrity": "sha512-sqx0/AdFFZ80dsiM5owmhtQyYl+zON1r+IY0m70I/ABRVy+I3br06xdUhoaxh3tcP7c0O/BQgb+VCfXa9Y34CA==",
+      "requires": {
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/stepper": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/stepper/-/stepper-2.3.0.tgz",
+      "integrity": "sha512-q80QX/NLrjJQIlBP1N+Q8GVJb7/HiOpMoK1PlP4denB/KxkU2K8GEjss8U2vklR1XsWJy1fwfj03+66Q78Uk/Q==",
+      "requires": {
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/styled-system": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.9.1.tgz",
+      "integrity": "sha512-jhYKBLxwOPi9/bQt9kqV3ELa/4CjmNNruTyXlPp5M0v0+pDMUngPp48mVLoskm9RKZGE0h1qpvj/jZ3K7c7t8w==",
+      "requires": {
+        "@chakra-ui/shared-utils": "2.0.5",
+        "csstype": "^3.0.11",
+        "lodash.mergewith": "4.6.2"
+      }
+    },
+    "@chakra-ui/switch": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-2.1.0.tgz",
+      "integrity": "sha512-uWHOaIDQdGh+mszxeppj5aYVepbkSK445KZlJJkfr9Bnr6sythTwM63HSufnVDiTEE4uRqegv9jEjZK2JKA+9A==",
+      "requires": {
+        "@chakra-ui/checkbox": "2.3.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/system": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-2.6.0.tgz",
+      "integrity": "sha512-MgAFRz9V1pW0dplwWsB99hx49LCC+LsrkMala7KXcP0OvWdrkjw+iu+voBksO3626+glzgIwlZW113Eja+7JEQ==",
+      "requires": {
+        "@chakra-ui/color-mode": "2.2.0",
+        "@chakra-ui/object-utils": "2.1.0",
+        "@chakra-ui/react-utils": "2.0.12",
+        "@chakra-ui/styled-system": "2.9.1",
+        "@chakra-ui/theme-utils": "2.0.19",
+        "@chakra-ui/utils": "2.0.15",
+        "react-fast-compare": "3.2.1"
+      }
+    },
+    "@chakra-ui/table": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-2.1.0.tgz",
+      "integrity": "sha512-o5OrjoHCh5uCLdiUb0Oc0vq9rIAeHSIRScc2ExTC9Qg/uVZl2ygLrjToCaKfaaKl1oQexIeAcZDKvPG8tVkHyQ==",
+      "requires": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/tabs": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-2.2.0.tgz",
+      "integrity": "sha512-ulN7McHZ322qlbJXg8S+IwdN8Axh8q0HzYBOHzSdcnVphEytfv9TsfJhN0Hx5yjkpekAzG5fewn33ZdIpIpKyQ==",
+      "requires": {
+        "@chakra-ui/clickable": "2.1.0",
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/lazy-utils": "2.0.5",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/tag": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-3.1.0.tgz",
+      "integrity": "sha512-Mn2u828z5HvqEBEG+tUJWe3al5tzN87bK2U0QfThx3+zqWbBCWBSCVfnWRtkNh80m+5a1TekexDAPZqu5G8zdw==",
+      "requires": {
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0"
+      }
+    },
+    "@chakra-ui/textarea": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-2.1.0.tgz",
+      "integrity": "sha512-4F7X/lPRsY+sPxYrWGrhh1pBtdnFvVllIOapzAwnjYwsflm+vf6c+9ZgoDWobXsNezJ9fcqN0FTPwaBnDvDQRQ==",
+      "requires": {
+        "@chakra-ui/form-control": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/theme": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.2.0.tgz",
+      "integrity": "sha512-q9mppdkhmaBnvOT8REr/lVNNBX/prwm50EzObJ+r+ErVhNQDc55gCFmtr+It3xlcCqmOteG6XUdwRCJz8qzOqg==",
+      "requires": {
+        "@chakra-ui/anatomy": "2.2.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/theme-tools": "2.1.0"
+      }
+    },
+    "@chakra-ui/theme-tools": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.1.0.tgz",
+      "integrity": "sha512-TKv4trAY8q8+DWdZrpSabTd3SZtZrnzFDwUdzhbWBhFEDEVR3fAkRTPpnPDtf1X9w1YErWn3QAcMACVFz4+vkw==",
+      "requires": {
+        "@chakra-ui/anatomy": "2.2.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "color2k": "^2.0.0"
+      }
+    },
+    "@chakra-ui/theme-utils": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-utils/-/theme-utils-2.0.19.tgz",
+      "integrity": "sha512-UQ+KvozTN86+0oA80rdQd1a++4rm4ulo+DEabkgwNpkK3yaWsucOxkDQpi2sMIMvw5X0oaWvNBZJuVyK7HdOXg==",
+      "requires": {
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/styled-system": "2.9.1",
+        "@chakra-ui/theme": "3.2.0",
+        "lodash.mergewith": "4.6.2"
+      }
+    },
+    "@chakra-ui/toast": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-7.0.0.tgz",
+      "integrity": "sha512-XQgSnn4DYRgfOBzBvh8GI/AZ7SfrO8wlVSmChfp92Nfmqm7tRDUT9x8ws/iNKAvMRHkhl7fmRjJ39ipeXYrMvA==",
+      "requires": {
+        "@chakra-ui/alert": "2.2.0",
+        "@chakra-ui/close-button": "2.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-timeout": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/styled-system": "2.9.1",
+        "@chakra-ui/theme": "3.2.0"
+      }
+    },
+    "@chakra-ui/tooltip": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-2.3.0.tgz",
+      "integrity": "sha512-2s23f93YIij1qEDwIK//KtEu4LLYOslhR1cUhDBk/WUzyFR3Ez0Ee+HlqlGEGfGe9x77E6/UXPnSAKKdF/cpsg==",
+      "requires": {
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-disclosure": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/transition": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-2.1.0.tgz",
+      "integrity": "sha512-orkT6T/Dt+/+kVwJNy7zwJ+U2xAZ3EU7M3XCs45RBvUnZDr/u9vdmaM/3D/rOpmQJWgQBwKPJleUXrYWUagEDQ==",
+      "requires": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/utils": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.0.15.tgz",
+      "integrity": "sha512-El4+jL0WSaYYs+rJbuYFDbjmfCcfGDmRY95GO4xwzit6YAPZBLcR65rOEwLps+XWluZTy1xdMrusg/hW0c1aAA==",
+      "requires": {
+        "@types/lodash.mergewith": "4.6.7",
+        "css-box-model": "1.2.1",
+        "framesync": "6.1.2",
+        "lodash.mergewith": "4.6.2"
+      }
+    },
+    "@chakra-ui/visually-hidden": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-2.1.0.tgz",
+      "integrity": "sha512-3OHKqTz78PX7V4qto+a5Y6VvH6TbU3Pg6Z0Z2KnDkOBP3Po8fiz0kk+/OSPzIwdcSsQKiocLi0c1pnnUPdMZPg==",
+      "requires": {}
+    },
     "@csstools/normalize.css": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
@@ -19015,6 +21569,132 @@
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
       "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
       "requires": {}
+    },
+    "@emotion/babel-plugin": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
+      "integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.1",
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/serialize": "^1.1.2",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
+        }
+      }
+    },
+    "@emotion/cache": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
+      "integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
+      "requires": {
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/sheet": "^1.2.2",
+        "@emotion/utils": "^1.2.1",
+        "@emotion/weak-memoize": "^0.3.1",
+        "stylis": "4.2.0"
+      }
+    },
+    "@emotion/hash": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
+      "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
+    },
+    "@emotion/is-prop-valid": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
+      "requires": {
+        "@emotion/memoize": "^0.8.1"
+      }
+    },
+    "@emotion/memoize": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+    },
+    "@emotion/react": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.1.tgz",
+      "integrity": "sha512-5mlW1DquU5HaxjLkfkGN1GA/fvVGdyHURRiX/0FHl2cfIfRxSOfmxEH5YS43edp0OldZrZ+dkBKbngxcNCdZvA==",
+      "requires": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.11.0",
+        "@emotion/cache": "^11.11.0",
+        "@emotion/serialize": "^1.1.2",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+        "@emotion/utils": "^1.2.1",
+        "@emotion/weak-memoize": "^0.3.1",
+        "hoist-non-react-statics": "^3.3.1"
+      }
+    },
+    "@emotion/serialize": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.2.tgz",
+      "integrity": "sha512-zR6a/fkFP4EAcCMQtLOhIgpprZOwNmCldtpaISpvz348+DP4Mz8ZoKaGGCQpbzepNIUWbq4w6hNZkwDyKoS+HA==",
+      "requires": {
+        "@emotion/hash": "^0.9.1",
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/unitless": "^0.8.1",
+        "@emotion/utils": "^1.2.1",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@emotion/sheet": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
+      "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
+    },
+    "@emotion/styled": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.0.tgz",
+      "integrity": "sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==",
+      "requires": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.11.0",
+        "@emotion/is-prop-valid": "^1.2.1",
+        "@emotion/serialize": "^1.1.2",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+        "@emotion/utils": "^1.2.1"
+      }
+    },
+    "@emotion/unitless": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+    },
+    "@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
+      "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
+      "requires": {}
+    },
+    "@emotion/utils": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
+      "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+    },
+    "@emotion/weak-memoize": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
+      "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
     },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -19696,6 +22376,11 @@
         "source-map": "^0.7.3"
       }
     },
+    "@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
+    },
     "@reduxjs/toolkit": {
       "version": "1.9.5",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.5.tgz",
@@ -20330,6 +23015,19 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
+    "@types/lodash": {
+      "version": "4.14.197",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.197.tgz",
+      "integrity": "sha512-BMVOiWs0uNxHVlHBgzTIqJYmj+PgCo4euloGF+5m4okL3rEYzM2EEv78mw8zWSMM57dM7kVIgJ2QDvwHSoCI5g=="
+    },
+    "@types/lodash.mergewith": {
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.7.tgz",
+      "integrity": "sha512-3m+lkO5CLRRYU0fhGRp7zbsGi6+BZj0uTVSwvcKU+nSlhjA9/QRNfuSGnD2mX6hQA7ZbmcCkzk5h4ZYGOtk14A==",
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -20746,6 +23444,24 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
+    "@zag-js/dom-query": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.10.5.tgz",
+      "integrity": "sha512-zm6wA5+kqU48it6afNjaUhjVSixKZruTKB23z0V1xBqKbuiLOMMOZ5oK26cTPSXtZ5CPhDNZ2Qk4pliS5n9SVw=="
+    },
+    "@zag-js/element-size": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@zag-js/element-size/-/element-size-0.10.5.tgz",
+      "integrity": "sha512-uQre5IidULANvVkNOBQ1tfgwTQcGl4hliPSe69Fct1VfYb2Fd0jdAcGzqQgPhfrXFpR62MxLPB7erxJ/ngtL8w=="
+    },
+    "@zag-js/focus-visible": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-0.10.5.tgz",
+      "integrity": "sha512-EhDHKLutMtvLFCjBjyIY6h1JoJJNXG3KJz7Dj1sh4tj4LWAqo/TqLvgHyUTB29XMHwoslFHDJHKVWmLGMi+ULQ==",
+      "requires": {
+        "@zag-js/dom-query": "0.10.5"
+      }
+    },
     "abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -20914,6 +23630,14 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
+      "integrity": "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==",
+      "requires": {
+        "tslib": "^2.0.0"
       }
     },
     "aria-query": {
@@ -21651,6 +24375,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
+    "color2k": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.2.tgz",
+      "integrity": "sha512-kJhwH5nAwb34tmyuqq/lgjEKzlFXn1U99NlnB6Ws4qVaERcRUYeYP1cBw6BJ4vxaWStAUEef4WMr7WjOCnBt8w=="
+    },
     "colord": {
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
@@ -21731,6 +24460,11 @@
         }
       }
     },
+    "compute-scroll-into-view": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
+      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -21773,6 +24507,14 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
     },
     "core-js": {
       "version": "3.32.0",
@@ -21830,6 +24572,14 @@
       "integrity": "sha512-VS90XWtsHGqoM0t4KpH053c4ehxZ2E6HtGI7x68YFV0pTo/QmkV/YFA+NnlvK8guxZVNWGQhVNJGC39Q8XF4OQ==",
       "requires": {
         "postcss-selector-parser": "^6.0.9"
+      }
+    },
+    "css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "requires": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "css-declaration-sorter": {
@@ -22200,6 +24950,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
+    },
+    "detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "detect-port-alt": {
       "version": "1.1.6",
@@ -23306,6 +26061,11 @@
         "pkg-dir": "^4.1.0"
       }
     },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -23328,6 +26088,14 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
+    },
+    "focus-lock": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.6.tgz",
+      "integrity": "sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==",
+      "requires": {
+        "tslib": "^2.0.3"
+      }
     },
     "follow-redirects": {
       "version": "1.15.2",
@@ -23465,6 +26233,47 @@
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
       "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA=="
     },
+    "framer-motion": {
+      "version": "10.16.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.16.0.tgz",
+      "integrity": "sha512-R+88Mkr/1dr7XHjacwptfJyrywRzQ1HZX3YSZtN4tFMBq1O8GGCbDEv31Nf/H08o0hUXLC87GkxsR/1bZgwXfw==",
+      "requires": {
+        "@emotion/is-prop-valid": "^0.8.2",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@emotion/is-prop-valid": {
+          "version": "0.8.8",
+          "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+          "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+          "optional": true,
+          "requires": {
+            "@emotion/memoize": "0.7.4"
+          }
+        },
+        "@emotion/memoize": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+          "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+          "optional": true
+        }
+      }
+    },
+    "framesync": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.1.2.tgz",
+      "integrity": "sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==",
+      "requires": {
+        "tslib": "2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -23537,6 +26346,11 @@
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
       }
+    },
+    "get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="
     },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.2",
@@ -24014,6 +26828,14 @@
         "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
+      }
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "ipaddr.js": {
@@ -26031,6 +28853,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
+    "lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -27603,6 +30430,14 @@
         }
       }
     },
+    "react-clientside-effect": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
+      "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
+      "requires": {
+        "@babel/runtime": "^7.12.13"
+      }
+    },
     "react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -27703,6 +30538,24 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "react-fast-compare": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.1.tgz",
+      "integrity": "sha512-xTYf9zFim2pEif/Fw16dBiXpe0hoy5PxcD8+OwBnTtNLfIm3g6WxhKNurY+6OmdH1u6Ta/W/Vl6vjbYP1MFnDg=="
+    },
+    "react-focus-lock": {
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.5.tgz",
+      "integrity": "sha512-h6vrdgUbsH2HeD5I7I3Cx1PPrmwGuKYICS+kB9m+32X/9xHRrAbxgvaBpG7BFBN9h3tO+C3qX1QAVESmi4CiIA==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^0.11.6",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.6",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      }
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -27732,6 +30585,27 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
+    },
+    "react-remove-scroll": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.6.tgz",
+      "integrity": "sha512-bO856ad1uDYLefgArk559IzUNeQ6SWH4QnrevIUjH+GczV56giDfl3h0Idptf2oIKxQmd1p9BN25jleKodTALg==",
+      "requires": {
+        "react-remove-scroll-bar": "^2.3.4",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      }
+    },
+    "react-remove-scroll-bar": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
+      "integrity": "sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==",
+      "requires": {
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.0.0"
+      }
     },
     "react-scripts": {
       "version": "5.0.1",
@@ -27786,6 +30660,16 @@
         "webpack-dev-server": "^4.6.0",
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
+      }
+    },
+    "react-style-singleton": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+      "requires": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^2.0.0"
       }
     },
     "read-cache": {
@@ -28653,6 +31537,11 @@
         "postcss-selector-parser": "^6.0.4"
       }
     },
+    "stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
+    },
     "sucrase": {
       "version": "3.34.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.34.0.tgz",
@@ -28942,6 +31831,11 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
     },
+    "tiny-invariant": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
+    },
     "tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -28959,6 +31853,11 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
     "toidentifier": {
       "version": "1.0.1",
@@ -29217,6 +32116,23 @@
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "use-callback-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "use-sidecar": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "requires": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
       }
     },
     "use-sync-external-store": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@chakra-ui/icons": "^2.1.0",
+    "@chakra-ui/react": "^2.8.0",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
     "@reduxjs/toolkit": "^1.9.5",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
@@ -12,6 +16,7 @@
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "axios": "^1.4.0",
+    "framer-motion": "^10.16.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.1.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,20 +3,39 @@ import logo from './logo.svg';
 import './App.css';
 import { Articles } from "./features/articles/Articles";
 import { Search } from "./features/search/Search";
+import { useGetArticlesQuery, useGetSearchResultsQuery } from "./redux/apiSlice";
 
 
 function App() {
   const [searchTerms, setSearchTerms] = React.useState<string>("");
   const searchTermUpdate = (searchTerms: string) => setSearchTerms(searchTerms);
+
+  const {
+    data: articles = [],
+    error: articlesError,
+    isLoading: isLoadingArticles,
+  } = useGetArticlesQuery('');
+  const {
+    data: searchResults = [],
+    error: searchResultsError,
+    isLoading: isLoadingSearchResults,
+  } = useGetSearchResultsQuery(searchTerms);
+
+  const isSearchingDisabled = !!articlesError || isLoadingArticles || !!searchResultsError || isLoadingSearchResults;
+
   return (
     <div className="App">
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
         <Search
           updateSearchTerms={searchTermUpdate}
+          isSearchingDisabled={isSearchingDisabled}
         />
         <Articles
-          searchTerms={searchTerms}
+          articles={articles}
+          searchResults={searchResults}
+          isLoading={isLoadingArticles}
+          isError={!!articlesError}
         />
       </header>
     </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,7 +8,6 @@ import { useGetArticlesQuery, useGetSearchResultsQuery } from "./redux/apiSlice"
 
 function App() {
   const [searchTerms, setSearchTerms] = React.useState<string>("");
-  const searchTermUpdate = (searchTerms: string) => setSearchTerms(searchTerms);
 
   const {
     data: articles = [],
@@ -28,7 +27,7 @@ function App() {
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
         <Search
-          updateSearchTerms={searchTermUpdate}
+          updateSearchTerms={setSearchTerms}
           isSearchingDisabled={isSearchingDisabled}
         />
         <Articles

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,13 +6,18 @@ import { Search } from "./features/search/Search";
 
 
 function App() {
-
+  const [searchTerms, setSearchTerms] = React.useState<string>("");
+  const searchTermUpdate = (searchTerms: string) => setSearchTerms(searchTerms);
   return (
     <div className="App">
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
-        <Search />
-        <Articles />
+        <Search
+          updateSearchTerms={searchTermUpdate}
+        />
+        <Articles
+          searchTerms={searchTerms}
+        />
       </header>
     </div>
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import logo from './logo.svg';
 import './App.css';
 import { Articles } from "./features/articles/Articles";
+import { Search } from "./features/search/Search";
 
 
 function App() {
@@ -10,6 +11,7 @@ function App() {
     <div className="App">
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
+        <Search />
         <Articles />
       </header>
     </div>

--- a/frontend/src/features/articles/Articles.tsx
+++ b/frontend/src/features/articles/Articles.tsx
@@ -3,11 +3,6 @@ import {Article, SearchResult } from "../../types";
 import { Spinner } from "@chakra-ui/react";
 
 
-const formatWikipediaUrl = (title: string) => {
-  const formattedTitle = title.replace(/ /g, "_");
-  return `https://en.wikipedia.org/wiki/${formattedTitle}`;
-};
-
 type Props = {
   articles: Article[];
   searchResults: SearchResult[];
@@ -15,6 +10,18 @@ type Props = {
   isError: boolean;
 }
 
+const formatWikipediaUrl = (title: string) => {
+  const formattedTitle = title.replace(/ /g, "_");
+  return `https://en.wikipedia.org/wiki/${formattedTitle}`;
+};
+
+const openWikipediaArticle = (title: string) => {
+  window.open(formatWikipediaUrl(title), "_blank", "noreferrer");
+};
+
+const getArticleStyle = (isArticleSelected: boolean) => {
+  return isArticleSelected ? { cursor: "pointer" } : { opacity: "25%" };
+}
 
 export const Articles: React.FC<Props> = ({articles, searchResults, isLoading, isError}) => {
 
@@ -40,10 +47,8 @@ export const Articles: React.FC<Props> = ({articles, searchResults, isLoading, i
               articles?.map((article: Article) => {
                 const includeArticle = isArticleInResults(article);
                 return (
-                  <div key={article.title} style={includeArticle ? {cursor: "pointer"} : {opacity: "25%"}}>
-                    <h3 onClick={() => includeArticle &&
-                      window.open(formatWikipediaUrl(article.title), "_blank", "noreferrer")}
-                    >
+                  <div key={article.title} style={getArticleStyle(includeArticle)}>
+                    <h3 onClick={() => includeArticle && openWikipediaArticle(article.title)}>
                       { article.title }
                     </h3>
                   </div>

--- a/frontend/src/features/articles/Articles.tsx
+++ b/frontend/src/features/articles/Articles.tsx
@@ -9,9 +9,14 @@ const formatWikipediaUrl = (title: string) => {
   return `https://en.wikipedia.org/wiki/${formattedTitle}`;
 };
 
-export const Articles = () => {
+type Props = {
+  searchTerms: string;
+}
+
+
+export const Articles: React.FC<Props> = ({searchTerms}) => {
   const { data: articles = [] } = useGetArticlesQuery('');
-  const { data: searchResults = [] } = useGetSearchResultsQuery('');
+  const { data: searchResults = [] } = useGetSearchResultsQuery(searchTerms);
 
   const matchingArticleTitles = searchResults.map((searchResult: SearchResult) => searchResult.title);
   const isArticleInResults = (article: Article) => matchingArticleTitles.includes(article.title);

--- a/frontend/src/features/articles/Articles.tsx
+++ b/frontend/src/features/articles/Articles.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import {Article, SearchResult } from "../../types";
 
 import { useGetArticlesQuery, useGetSearchResultsQuery } from "../../redux/apiSlice";
+import { Spinner } from "@chakra-ui/react";
 
 
 const formatWikipediaUrl = (title: string) => {
@@ -15,7 +16,7 @@ type Props = {
 
 
 export const Articles: React.FC<Props> = ({searchTerms}) => {
-  const { data: articles = [] } = useGetArticlesQuery('');
+  const { data: articles = [], error, isLoading} = useGetArticlesQuery('');
   const { data: searchResults = [] } = useGetSearchResultsQuery(searchTerms);
 
   const matchingArticleTitles = searchResults.map((searchResult: SearchResult) => searchResult.title);
@@ -23,18 +24,35 @@ export const Articles: React.FC<Props> = ({searchTerms}) => {
 
   return (
     <div>
-      {articles.map((article: Article) => {
-        const includeArticle = isArticleInResults(article);
-        return (
-          <div key={article.title} style={includeArticle ? {cursor: "pointer"} : {opacity: "25%"}}>
-            <h3 onClick={() => includeArticle &&
-              window.open(formatWikipediaUrl(article.title), "_blank", "noreferrer")}
-            >
-              {article.title }
-            </h3>
-          </div>
+      { error ?
+        (
+          <>
+            <div>Oh no, there was an error loading your articles!</div>
+            <div>Please refresh your browser</div>
+          </>
+        ) : (
+          isLoading ?
+            (
+              <>
+                <div>Loading your random Wikipedia articles...</div>
+                <Spinner size='xl' />
+              </>
+            ) : (
+              articles?.map((article: Article) => {
+                const includeArticle = isArticleInResults(article);
+                return (
+                  <div key={article.title} style={includeArticle ? {cursor: "pointer"} : {opacity: "25%"}}>
+                    <h3 onClick={() => includeArticle &&
+                      window.open(formatWikipediaUrl(article.title), "_blank", "noreferrer")}
+                    >
+                      { article.title }
+                    </h3>
+                  </div>
+                )
+              })
+            )
         )
-      })}
+      }
     </div>
   )
 }

--- a/frontend/src/features/articles/Articles.tsx
+++ b/frontend/src/features/articles/Articles.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
 import {Article, SearchResult } from "../../types";
-
-import { useGetArticlesQuery, useGetSearchResultsQuery } from "../../redux/apiSlice";
 import { Spinner } from "@chakra-ui/react";
 
 
@@ -11,20 +9,21 @@ const formatWikipediaUrl = (title: string) => {
 };
 
 type Props = {
-  searchTerms: string;
+  articles: Article[];
+  searchResults: SearchResult[];
+  isLoading: boolean;
+  isError: boolean;
 }
 
 
-export const Articles: React.FC<Props> = ({searchTerms}) => {
-  const { data: articles = [], error, isLoading} = useGetArticlesQuery('');
-  const { data: searchResults = [] } = useGetSearchResultsQuery(searchTerms);
+export const Articles: React.FC<Props> = ({articles, searchResults, isLoading, isError}) => {
 
   const matchingArticleTitles = searchResults.map((searchResult: SearchResult) => searchResult.title);
   const isArticleInResults = (article: Article) => matchingArticleTitles.includes(article.title);
 
   return (
     <div>
-      { error ?
+      { isError ?
         (
           <>
             <div>Oh no, there was an error loading your articles!</div>

--- a/frontend/src/features/search/Search.tsx
+++ b/frontend/src/features/search/Search.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import {IconButton, Input, InputGroup, InputLeftElement} from '@chakra-ui/react'
+import { SearchIcon } from "@chakra-ui/icons";
+
+export const Search = () => {
+
+  const handleClickSearch = () => { console.log("Search") };
+
+  return (
+    <InputGroup width={"60%"} marginBottom={"8px"}>
+      <InputLeftElement>
+        <IconButton aria-label='Search articles' icon={<SearchIcon />} onClick={handleClickSearch}/>
+      </InputLeftElement>
+      <Input placeholder='Search your articles...' textAlign={"center"} />
+    </InputGroup>
+  )
+}

--- a/frontend/src/features/search/Search.tsx
+++ b/frontend/src/features/search/Search.tsx
@@ -35,6 +35,7 @@ export const Search: React.FC<Props> = ({
         value={searchTerms}
         onChange={handleSearchTermsChange}
         isDisabled={isSearchingDisabled}
+        onKeyDown={(event) => {if (event.key === 'Enter') {handleClickSearch()} }}
       />
     </InputGroup>
   )

--- a/frontend/src/features/search/Search.tsx
+++ b/frontend/src/features/search/Search.tsx
@@ -1,23 +1,20 @@
 import React from 'react'
 import {IconButton, Input, InputGroup, InputLeftElement} from '@chakra-ui/react'
 import { SearchIcon } from "@chakra-ui/icons";
-import { useGetArticlesQuery } from "../../redux/apiSlice";
 
 type Props = {
   updateSearchTerms: (searchTerms: string) => void;
+  isSearchingDisabled?: boolean;
 };
 
 
 export const Search: React.FC<Props> = ({
   updateSearchTerms,
+  isSearchingDisabled,
 }) => {
-  const { error, isLoading } = useGetArticlesQuery('');
-
   const [searchTerms, setSearchTerms] = React.useState<string>("");
   const handleSearchTermsChange = (event: React.ChangeEvent<HTMLInputElement>) => setSearchTerms(event.target.value);
   const handleClickSearch = () => { updateSearchTerms(searchTerms) };
-
-  const isSearchingDisabled = error ? true : isLoading;
 
   return (
     <InputGroup width={"60%"} marginBottom={"8px"}>

--- a/frontend/src/features/search/Search.tsx
+++ b/frontend/src/features/search/Search.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {IconButton, Input, InputGroup, InputLeftElement} from '@chakra-ui/react'
 import { SearchIcon } from "@chakra-ui/icons";
+import { useGetArticlesQuery } from "../../redux/apiSlice";
 
 type Props = {
   updateSearchTerms: (searchTerms: string) => void;
@@ -10,20 +11,30 @@ type Props = {
 export const Search: React.FC<Props> = ({
   updateSearchTerms,
 }) => {
+  const { error, isLoading } = useGetArticlesQuery('');
+
   const [searchTerms, setSearchTerms] = React.useState<string>("");
   const handleSearchTermsChange = (event: React.ChangeEvent<HTMLInputElement>) => setSearchTerms(event.target.value);
   const handleClickSearch = () => { updateSearchTerms(searchTerms) };
 
+  const isSearchingDisabled = error ? true : isLoading;
+
   return (
     <InputGroup width={"60%"} marginBottom={"8px"}>
       <InputLeftElement>
-        <IconButton aria-label='Search articles' icon={<SearchIcon />} onClick={handleClickSearch}/>
+        <IconButton
+          aria-label='Search articles'
+          icon={<SearchIcon />}
+          onClick={handleClickSearch}
+          isDisabled={isSearchingDisabled}
+        />
       </InputLeftElement>
       <Input
         placeholder='Search your articles...'
         textAlign={"center"}
         value={searchTerms}
         onChange={handleSearchTermsChange}
+        isDisabled={isSearchingDisabled}
       />
     </InputGroup>
   )

--- a/frontend/src/features/search/Search.tsx
+++ b/frontend/src/features/search/Search.tsx
@@ -2,16 +2,29 @@ import React from 'react'
 import {IconButton, Input, InputGroup, InputLeftElement} from '@chakra-ui/react'
 import { SearchIcon } from "@chakra-ui/icons";
 
-export const Search = () => {
+type Props = {
+  updateSearchTerms: (searchTerms: string) => void;
+};
 
-  const handleClickSearch = () => { console.log("Search") };
+
+export const Search: React.FC<Props> = ({
+  updateSearchTerms,
+}) => {
+  const [searchTerms, setSearchTerms] = React.useState<string>("");
+  const handleSearchTermsChange = (event: React.ChangeEvent<HTMLInputElement>) => setSearchTerms(event.target.value);
+  const handleClickSearch = () => { updateSearchTerms(searchTerms) };
 
   return (
     <InputGroup width={"60%"} marginBottom={"8px"}>
       <InputLeftElement>
         <IconButton aria-label='Search articles' icon={<SearchIcon />} onClick={handleClickSearch}/>
       </InputLeftElement>
-      <Input placeholder='Search your articles...' textAlign={"center"} />
+      <Input
+        placeholder='Search your articles...'
+        textAlign={"center"}
+        value={searchTerms}
+        onChange={handleSearchTermsChange}
+      />
     </InputGroup>
   )
 }

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -5,13 +5,16 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { Provider } from 'react-redux'
 import { store } from './redux/store'
+import { ChakraProvider } from '@chakra-ui/react'
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 root.render(
   <Provider store={store}>
-    <App />
+    <ChakraProvider>
+      <App />
+    </ChakraProvider>
   </Provider>
 );
 


### PR DESCRIPTION
This PR adds a functional search bar to enable the user to search amongst the content of the random Wikipedia articles their app has collected. The user can now input search terms (either by pressing the Enter button or clicking the search icon button) which are sent to the BE, and in turn will update the articles list to highlight the relevant articles (and make them clickable, opening up the related Wikipedia article in a separate tab).

![image](https://github.com/LukeScales1/wikipedia-search/assets/40272781/8cdb5683-0a66-47bf-9427-6a8a219c18ff)

ChakraUI was added to the frontend project dependencies to get some nice, easily customisable UI components for this feature. Material UI was explored but it was a little more fidgety to implement and it needs some extra boilerplate to work with TypeScript.

A loading state was added which shows text and a spinner if articles are loading from the DB (e.g. during application launch):
![image](https://github.com/LukeScales1/wikipedia-search/assets/40272781/46c1a359-2b6a-481d-9373-7f8790fe6288)

An error state was also added to encourage the user to refresh the browser if an error occurs - this should only really happen if the BE app is not running:
![image](https://github.com/LukeScales1/wikipedia-search/assets/40272781/cc4d3e46-842b-4c20-9d1b-4c51ff85670e)

For both the error and the loading states, the search bar and icon button are disabled.