### PR TITLE
Feat/session and lifecycle management

### DIFF
--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -1,6 +1,6 @@
 pydantic~=1.10.2
 requests~=2.28.1
-fastapi~=0.86.0
+fastapi~=0.101.0
 uvicorn~=0.19.0
 nltk~=3.7
 beautifulsoup4~=4.11.1

--- a/backend/src/index/schema.py
+++ b/backend/src/index/schema.py
@@ -4,7 +4,3 @@ from pydantic import BaseModel
 class SearchResult(BaseModel):
     title: str
     ranking: float
-
-
-class SearchResponse(BaseModel):
-    __root__: list[SearchResult]

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -2,17 +2,19 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Union
+from contextlib import asynccontextmanager
+from typing import Annotated, Optional, Union
 
 import requests
 import wikipedia.service as article_service
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import Depends, FastAPI, Query
 from fastapi.middleware.cors import CORSMiddleware
 from index.indexer import create_or_update_inverted_index, rank_documents
 from index.nlp import lemmatize, set_up_nltk
 from index.schema import SearchResult
 from requests import Session
 from sqlalchemy import create_engine
+from sqlalchemy.orm import Session as DBSession
 from sqlalchemy.orm import sessionmaker
 from wikipedia.client import fetch_article_list, fetch_parsed_text
 from wikipedia.models import Article
@@ -23,35 +25,31 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 logging.basicConfig()
 
-app = FastAPI()
-
-origins = [
-    "http://localhost",
-    "http://localhost:3000",
-]
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=origins,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
 set_up_nltk()
 
-s = requests.Session()
 text_processor = lemmatize
 
 NUMBER_OF_ARTICLES = 10
 
 
 DB_CONNECTION = "postgresql+psycopg2://postgres:password@db:5432/wiki-search"
-
 engine = create_engine(DB_CONNECTION)
+db_session_maker = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
-DbSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-db_session = DbSession()
+
+async def get_db_session():
+    """
+    Get a managed database session from the database connection pool.
+    """
+    db_session = None
+    try:
+        db_session = db_session_maker()
+        yield db_session
+    finally:
+        if db_session:
+            db_session.close()
+
+DbSessionDeps = Annotated[Optional[DBSession], Depends(get_db_session)]
 
 
 def get_and_parse_random_articles(
@@ -71,7 +69,8 @@ def get_and_parse_random_articles(
     ]
 
 
-def _index_documents(session: Session):
+def _index_documents(db_session: DBSession):
+    """ Helper function for indexing documents. """
     logger.info("Indexing documents...")
     start_time = time.time()
     fetch_time = None
@@ -80,7 +79,8 @@ def _index_documents(session: Session):
 
     if not db_articles:
         logger.info("No articles found in database. Fetching some from Wikipedia...")
-        articles = get_and_parse_random_articles(session, ArticleTitlesGet(rnlimit=NUMBER_OF_ARTICLES))
+        with requests.Session() as session:
+            articles = get_and_parse_random_articles(session, ArticleTitlesGet(rnlimit=NUMBER_OF_ARTICLES))
         fetch_time = time.time()
         logger.info(f"{len(articles)} articles fetched!")
         article_service.add_articles_bulk(
@@ -108,7 +108,27 @@ def _index_documents(session: Session):
     logger.info(f"Time taken to index articles: {index_stop_time - index_start_time}")
 
 
-_index_documents(s)
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    db_session = db_session_maker()
+    _index_documents(db_session)
+    db_session.close()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
+origins = [
+    "http://localhost",
+    "http://localhost:3000",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.get("/")
@@ -118,25 +138,27 @@ async def index():
 
 
 @app.get("/articles", response_model=list[ArticleSchema])
-async def get_articles(limit: int = Query(default=0, gt=0, le=100), offset: int = Query(default=0, ge=0)):
+async def get_articles(
+        db_session: DbSessionDeps,
+        limit: int = Query(default=0, gt=0, le=100),
+        offset: int = Query(default=0, ge=0),
+):
     """ Get articles from the DB, with optional limit and offset.
 
     Defaults to all articles in the DB if no limit provided. Offset can be used without a limit.
 
+    :param db_session: The database session.
     :param limit: The maximum number of articles to return.
     :param offset: The number of articles to skip.
-    :raises HTTPException: (404) If no articles are found.
     """
-    articles = article_service.filter_articles(session=db_session, limit=limit, offset=offset)
-    if not articles:
-        raise HTTPException(status_code=404, detail="No articles found!")
-    return articles
+    return article_service.filter_articles(session=db_session, limit=limit, offset=offset)
 
 
 @app.post("/articles", response_model=list[ArticleSchema])
-async def fetch_new_articles():
+async def fetch_new_articles(db_session: Annotated[DBSession, Depends(get_db_session)]):
     """ Get some random articles from Wikipedia, add to the DB, and reindex. """
-    new_articles = get_and_parse_random_articles(s, ArticleTitlesGet(rnlimit=NUMBER_OF_ARTICLES))
+    with requests.Session() as session:
+        new_articles = get_and_parse_random_articles(session, ArticleTitlesGet(rnlimit=NUMBER_OF_ARTICLES))
     article_service.add_articles_bulk(
         session=db_session,
         articles=[

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -140,7 +140,7 @@ async def fetch_new_articles():
     article_service.add_articles_bulk(
         session=db_session,
         articles=[
-            Article.from_dict(article_schema.dict())
+            article_schema.to_db_model()
             for article_schema in new_articles
         ]
     )

--- a/backend/src/wikipedia/schema.py
+++ b/backend/src/wikipedia/schema.py
@@ -47,10 +47,6 @@ class ParsedText(BaseModel):
         )
 
 
-class ProcessedText(BaseModel):
-    __root__: list[str]
-
-
 """
 Request Schema
 """

--- a/backend/src/wikipedia/schema.py
+++ b/backend/src/wikipedia/schema.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from common.schema import Actions, DefaultParams
 from pydantic import BaseModel, Field, validator
-from wikipedia.client import parse_article_html_or_none, parse_text_from_html
+from wikipedia.models import Article
 
 
 class ListTypes(Enum):
@@ -14,6 +14,15 @@ class ListTypes(Enum):
     enum to facilitate any further work. See https://www.mediawiki.org/wiki/API:Lists/All for more.
     """
     RANDOM = "random"
+
+
+def reformat_tokenized_content(content: str) -> list[str]:
+    """ Reformats the string representation of tokenized content into a list of strings.
+
+    Removes any whitespace, braces and quotes, and splits on commas.
+    """
+    import re
+    return re.split(r"[,\s]+", re.sub(r"[\[\]{}']", "", content))
 
 
 class ArticleSchema(BaseModel):
@@ -29,21 +38,18 @@ class ArticleSchema(BaseModel):
             return None
 
         if type(value) is str:
-            return value.replace("{", "").replace("}", "").split(",")
+            return reformat_tokenized_content(value)
 
         return value
 
     class Config:
         orm_mode = True
 
-
-class ParsedText(BaseModel):
-    text: str
-
-    @classmethod
-    def from_html(cls, html: str) -> ParsedText:
-        return cls(
-            text=parse_text_from_html(html)
+    def to_db_model(self) -> Article:
+        """ Convert an ArticleSchema to a DB model. """
+        return Article(
+            title=self.title,
+            tokenized_content=",".join(self.tokenized_content),
         )
 
 
@@ -63,25 +69,3 @@ class ContentGet(DefaultParams):
     """ Schema for fetching the content of an article. """
     action: Actions = Actions.PARSE
     page: str
-
-
-"""
-Response Schema
-"""
-
-
-class ArticlesResponse(BaseModel):
-    __root__: list[ArticleSchema]
-
-
-class ContentGetResponse(BaseModel):
-    data: str
-
-    @validator('data', pre=True)
-    def validate_text(cls, value: dict):
-        data = parse_article_html_or_none(value)
-
-        if not data:
-            raise ValueError("No results returned from scrape request!")
-
-        return data


### PR DESCRIPTION
This PR cleans up the backend application by removing unused endpoints (now that the application's intent/function has been fleshed out) and removes unused/unnecessary schemas.

It introduces lifecycle management of the application to run indexing on startup of the app and also introduces session management for both the DB connections (which now operate on a per-request basis instead of one long-running connection) and the requests session used to fetch Wikipedia data (which now uses the `requests.Session` inbuilt context manager to only leave the connection open as long as is needed for each operation).

Also adds some helper methods for parsing data from DB <-> Schema