### PR TITLE
Tests/be tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Ensure that Docker is [installed](https://docs.docker.com/engine/install/) and t
 [daemon is running](https://docs.docker.com/config/daemon/start/) (it will typically be running automatically, if not
 the following command will complain at you and you can start it manually then).
 In the root directory of the project, run:
+
 ```docker-compose up --build```
 
 This will build the Docker image and run the backend app on port 8000, and the frontend app on port 3000 by default.
@@ -101,4 +102,13 @@ Example result:
 
 ## Running tests
 
-To run the automated tests locally, navigate to the `backend` directory and simply execute `pytest`
+To run the automated tests locally, navigate to the `backend` directory and install the BE project as an editable
+dependency:
+
+```pip install -e .```
+
+Ensure you have the test requirements installed:
+
+```pip install -Ur requirements/test.txt```
+
+Then simply execute `pytest`.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/backend/requirements/test.txt
+++ b/backend/requirements/test.txt
@@ -1,3 +1,4 @@
 -r base.txt
 
-pre-commit
+pytest
+httpx

--- a/backend/setup.cfg
+++ b/backend/setup.cfg
@@ -1,0 +1,12 @@
+[metadata]
+name = wiki-search-backend
+version = 0.0.1
+
+[options]
+package_dir =
+    = src
+packages = find:
+python_requires = >=3.9
+
+[options.packages.find]
+where = src

--- a/backend/src/test_main.py
+++ b/backend/src/test_main.py
@@ -26,6 +26,9 @@ Base.metadata.create_all(bind=engine)
 
 
 def override_get_db():
+    """
+    Override the `get_db_session` FastAPI app dependency to use a test database session.
+    """
     db = None
     try:
         db = TestingSessionLocal()
@@ -51,7 +54,7 @@ TEST_ARTICLE = ArticleSchema(
 
 @pytest.fixture
 def article():
-    """ Returns a test article. """
+    """ Returns a test article DB model. """
     return TEST_ARTICLE.to_db_model()
 
 
@@ -59,7 +62,7 @@ def article():
 def add_article(article):
     """
     Add a test article to the database and manages removal after test.
-    :param article:
+    :param article: test article fixture
     """
     db_session = TestingSessionLocal()
     db_session.add(article)
@@ -90,7 +93,12 @@ def test_get_articles_returns_empty_array_if_no_records():
 
 
 def test_get_articles(add_article):
-    """ Test that the get_articles endpoint returns the correct number of records. """
+    """ Test that the get_articles endpoint returns the correct number of records.
+
+    In this case, we have only one article added from fixtures.
+
+    :param add_article: fixture to add an article to the database.
+    """
     response = client.get("/articles")
     assert response.status_code == 200
     assert len(response.json()) == 1
@@ -98,7 +106,12 @@ def test_get_articles(add_article):
 
 
 def test_get_article_parses_tokenized_content_correctly(add_article):
-    """ Test that article content is correctly parsed between the database and the API. """
+    """ Test that article content is correctly parsed between the database and the API.
+
+    In this case, we have only one article added from fixtures.
+
+    :param add_article: fixture to add an article to the database.
+    """
     response = client.get("/articles")
     assert response.status_code == 200
     assert response.json()[0]["tokenized_content"] == TEST_ARTICLE.tokenized_content
@@ -108,6 +121,9 @@ def test_get_search_results(add_article, index_documents):
     """ Test that the search endpoint returns the correct results.
 
     In this case, we have only one article added from fixtures.
+
+    :param add_article: fixture to add an article to the database.
+    :param index_documents: fixture to index documents in the database.
     """
     response = client.get("/search?query=creator")
     assert response.status_code == 200
@@ -116,7 +132,12 @@ def test_get_search_results(add_article, index_documents):
 
 
 def test_get_search_results_empty_response(add_article, index_documents):
-    """ Test that the search endpoint returns an empty response if no valid articles are found. """
+    """ Test that the search endpoint returns an empty response if no valid articles are found.
+
+    In this case, we have only one article added from fixtures, but the query is irrelevant to the article.
+
+    :param add_article: fixture to add an article to the database.
+    """
     response = client.get("/search?query=football")
     assert response.status_code == 200
     assert len(response.json()) == 0

--- a/backend/src/test_main.py
+++ b/backend/src/test_main.py
@@ -1,73 +1,122 @@
-# flake8: noqa E402
-import os
-import sys
-import unittest
+import logging
 
 import pytest
+from common.models import Base
 from fastapi.testclient import TestClient
+from main import _index_documents, app, get_db_session
+from sqlalchemy import StaticPool, create_engine
+from sqlalchemy.orm import sessionmaker
+from wikipedia.schema import ArticleSchema
 
-PROJECT_PATH = os.getcwd()
-SOURCE_PATH = os.path.join(
-    PROJECT_PATH, "src"
+logging.basicConfig()
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+
+
+SQLALCHEMY_DATABASE_URL = "sqlite://"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
 )
-sys.path.append(SOURCE_PATH)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
-from src.index.indexer import _reset_index
-from src.main import _index_documents, app, s, text_processor
-from src.wikipedia.client import get_parsed_text
-from src.wikipedia.schema import ArticleSchema
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = None
+    try:
+        db = TestingSessionLocal()
+        yield db
+    finally:
+        if db:
+            db.close()
+
+
+app.dependency_overrides[get_db_session] = override_get_db
 
 client = TestClient(app)
-TEST_SEARCH = "Linus_Torvalds"
 
 
-@pytest.fixture(scope="class")
-def index_documents():
-    _reset_index()
-    articles = [
-        ArticleSchema(
-            title=TEST_SEARCH,
-            tokenized_content=text_processor(
-                get_parsed_text(s, page_name=TEST_SEARCH)
-            )
-        )
+TEST_ARTICLE = ArticleSchema(
+    title="Linus Torvalds",
+    tokenized_content=[
+        "Linus", "Benedict", "Torvalds", "is", "a", "Finnish", "American", "software", "engineer", "who", "is",
+        "the", "creator", "and", "historically", "the", "principal", "developer", "of", "the", "Linux", "kernel",
     ]
-    _index_documents(s, articles)
+)
 
 
-def mock_random_article_response(*args, **kwargs) -> dict:
-    return {
-        "query": {
-            "random": [
-                {"title": TEST_SEARCH}
-            ]
-        }
-    }
+@pytest.fixture
+def article():
+    """ Returns a test article. """
+    return TEST_ARTICLE.to_db_model()
 
 
-@pytest.mark.usefixtures("index_documents")
-class TestWiki(unittest.TestCase):
-    def test_get_articles(self):
-        response = client.get("/articles")
-        assert response.status_code == 200
-        assert len(response.json()) == 5
+@pytest.fixture(scope="function")
+def add_article(article):
+    """
+    Add a test article to the database and manages removal after test.
+    :param article:
+    """
+    db_session = TestingSessionLocal()
+    db_session.add(article)
+    db_session.commit()
+    logger.info("Added test article to the database.")
+    yield
+    db_session.delete(article)
+    db_session.commit()
+    db_session.close()
 
-    def test_get_content(self):
-        response = client.get(f"/content/{TEST_SEARCH}")
-        assert response.status_code == 200
-        assert "<div class=" in response.json()["data"]
 
-    def test_parse_content(self):
-        response = client.get(f"/parse/{TEST_SEARCH}")
-        assert response.status_code == 200
-        assert "Creator and lead developer of the Linux kernel" in response.json()["text"]
+@pytest.fixture
+def index_documents():
+    """
+    Indexes documents in test session.
+    """
+    db_session = TestingSessionLocal()
+    _index_documents(db_session)
+    logger.info("Indexed documents.")
+    db_session.close()
 
-    def test_process_content(self):
-        response = client.get(f"/process/{TEST_SEARCH}")
-        assert response.status_code == 200
-        assert response.json()[0] == "creator"
 
-    def test_search(self):
-        response = client.get("/search?query=creator")
-        assert response.status_code == 200
-        assert TEST_SEARCH in response.json()["results"].keys()
+def test_get_articles_returns_empty_array_if_no_records():
+    """ Test that the get_articles endpoint returns an empty array if there are no records in the database. """
+    response = client.get("/articles")
+    assert response.status_code == 200
+    assert len(response.json()) == 0
+
+
+def test_get_articles(add_article):
+    """ Test that the get_articles endpoint returns the correct number of records. """
+    response = client.get("/articles")
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+    assert response.json()[0]["title"] == TEST_ARTICLE.title
+
+
+def test_get_article_parses_tokenized_content_correctly(add_article):
+    """ Test that article content is correctly parsed between the database and the API. """
+    response = client.get("/articles")
+    assert response.status_code == 200
+    assert response.json()[0]["tokenized_content"] == TEST_ARTICLE.tokenized_content
+
+
+def test_get_search_results(add_article, index_documents):
+    """ Test that the search endpoint returns the correct results.
+
+    In this case, we have only one article added from fixtures.
+    """
+    response = client.get("/search?query=creator")
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+    assert response.json()[0]["title"] == TEST_ARTICLE.title
+
+
+def test_get_search_results_empty_response(add_article, index_documents):
+    """ Test that the search endpoint returns an empty response if no valid articles are found. """
+    response = client.get("/search?query=football")
+    assert response.status_code == 200
+    assert len(response.json()) == 0


### PR DESCRIPTION
This PR adds a `setup.cfg` and `pyproject.toml` files so that the backend project can be installed as an editable dependcy, preventing the need for hacks to set the source path for tests. It also rewrites the tests to align with the current implementation of the app, and implements a mock SQLite DB to run tests. Since no Postgres-specific features are used this should be fine for now.

Includes test fixtures for adding a test article and indexing on the test-based data. The fixture for adding a test article manages the teardown of the added article so that it doesn't interfere with other tests.