### PR TITLE
Feat/indexing cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: isort
         name: Sort imports using iSort
-        args: [ -p=backend/src, -p=tests, --line-length=120, -e ]
+        args: [ -p=backend/src, --line-length=120, -e ]
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,3 +4,6 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.isort]
+src_paths = ["src"]

--- a/backend/src/index/indexer.py
+++ b/backend/src/index/indexer.py
@@ -10,8 +10,6 @@ from typing import Iterable, Optional
 from index.schema import SearchResult
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-logging.basicConfig()
 
 
 def _reset_cached_properties(object_instance, properties: Iterable[str]):

--- a/backend/src/settings.py
+++ b/backend/src/settings.py
@@ -1,0 +1,16 @@
+"""
+This file contains all the settings for the application.
+"""
+import logging
+
+from index.nlp import lemmatize, set_up_nltk
+
+logging.basicConfig()
+
+set_up_nltk()
+
+text_processor = lemmatize
+
+NUMBER_OF_ARTICLES = 10
+
+DB_CONNECTION = "postgresql+psycopg2://postgres:password@db:5432/wiki-search"

--- a/backend/src/test_main.http
+++ b/backend/src/test_main.http
@@ -1,7 +1,0 @@
-# Test your FastAPI endpoints
-
-
-GET http://127.0.0.1:8000/articles
-Accept: application/json
-
-###

--- a/backend/src/wikipedia/service.py
+++ b/backend/src/wikipedia/service.py
@@ -18,13 +18,22 @@ logger = logging.getLogger(__name__)
 
 
 def get_article(session: Session, page_name: str) -> Article | None:
-    """ Get an article by title. """
+    """ Get an article by title.
+
+    :param session: The database session.
+    :param page_name: The title of the article.
+    """
     query = select(Article).where(Article.c.title == page_name)
     return session.execute(query).first()
 
 
 def filter_articles(session: Session, limit: int | None = None, offset: int | None = None) -> Sequence[Article]:
-    """ Get all articles from the database. """
+    """ Get all articles from the database.
+
+    :param session: The database session.
+    :param limit: The (optional) maximum number of articles to return.
+    :param offset: The (optional) number of articles to skip.
+    """
     query = select(Article)
     if limit:
         query = query.limit(limit)
@@ -35,25 +44,41 @@ def filter_articles(session: Session, limit: int | None = None, offset: int | No
 
 
 def add_article(session: Session, article: Article):
-    """ Add an article to the database. """
+    """ Add an article to the database.
+
+    :param session: The database session.
+    :param article: The article to add.
+    """
     session.add(article)
     session.commit()
 
 
 def add_articles_bulk(session: Session, articles: list[Article]):
-    """ Add a list of articles to the database. """
+    """ Add a list of articles to the database.
+
+    :param session: The database session.
+    :param articles: The articles to add.
+    """
     session.bulk_save_objects(articles)
     session.commit()
 
 
 def update_article(session: Session, article: Article):
-    """ Update an article in the database. """
+    """ Update an article in the database.
+
+    :param session: The database session.
+    :param article: The article to update.
+    """
     session.merge(article)
     session.commit()
 
 
 def delete_article(session: Session, article: Article):
-    """ Delete an article from the database. """
+    """ Delete an article from the database.
+
+    :param session: The database session.
+    :param article: The article to delete.
+    """
     session.delete(article)
     session.commit()
 


### PR DESCRIPTION
This PR abstracts away some application setup logic to the new `settings.py` file, separates some concerns for the initial indexing of documents, and implements some DRY code for getting articles from the DB in schema format and also for fetching new articles from Wikipedia and adding them to the DB. 
Also fixes a bug/oversight in isort implementation that resulted in 1st party packages being considered as 3rd party.